### PR TITLE
We don't need the --insecure option anymore.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,10 +39,9 @@ Getting an authentication token
 - open up the devtools console in your browser, and find the request for the current page.
 - right click to open a context menu and select 'copy as cURL'
 - paste that into a terminal.  It should have your saml cookie.
-- before hitting enter, edit the command to add the following two options:
+- before hitting enter, edit the command to add the following option:
 
   - ``-H 'Accept: application/json'``, to tell the API you want data
-  - ``--insecure``, because we have a self-signed cert
 
 - the command should print out your token.
 

--- a/fedmsg.d/pdcupdater-example.py
+++ b/fedmsg.d/pdcupdater-example.py
@@ -6,7 +6,7 @@ config = {
     # Credentials to talk to PDC
     'pdcupdater.pdc': {
         'server': 'https://pdc.fedoraproject.org/rest_api/v1/',
-        'insecure': True,  # Just because we have a self-signed cert in the cloud
+        'insecure': False,  # Enable if using a self-signed cert
         'token': 'AWESOME_SECRET_STRING_GOES_HERE',
         # XXX - getting the token is a bit of a pain, but here's a walk through
         # 1) go to https://pdc.fedoraproject.org/ in your browser and login.
@@ -14,9 +14,8 @@ config = {
         # 3) open up the devtools console in your browser, and find the request for the current page.
         # 4) right click to open a context menu and select 'copy as cURL'
         # 5) paste that into a terminal.  It should have your saml cookie.
-        # 6) before hitting enter, edit the command to add the following two options
+        # 6) before hitting enter, edit the command to add the following option
         #       -H 'Accept: application/json'   # to tell the API you want data
-        #       --insecure                      # because we have a self-signed cert
         # 7) the command should print out your token.
     },
 


### PR DESCRIPTION
Previously we were hosting PDC on fedorainfracloud.org, which uses a
self-signed certificate. We've since migrated it to fedoraproject.org, and no
longer need this option.

:closed_lock_with_key: 