### PR TITLE
A stab at modelling container-to-rpm deps.

### DIFF
--- a/fedmsg.d/pdcupdater-example.py
+++ b/fedmsg.d/pdcupdater-example.py
@@ -52,6 +52,7 @@ config = {
         # https://fedoraproject.org/wiki/User:Ralph/Drafts/Infrastructure/Factory2/ModellingDeps
         'pdcupdater.handlers.depchain.rpms:NewRPMBuildTimeDepChainHandler',
         'pdcupdater.handlers.depchain.rpms:NewRPMRunTimeDepChainHandler',
+        'pdcupdater.handlers.depchain.containers:ContainerRPMInclusionDepChainHandler',
     ],
 
     # Augment the base fedmsg logging config to also handle pdcupdater loggers.

--- a/pdcupdater/handlers/depchain/base.py
+++ b/pdcupdater/handlers/depchain/base.py
@@ -109,10 +109,10 @@ class BaseKojiDepChainHandler(pdcupdater.handlers.BaseHandler):
 
             rpms = [_format_rpm_filename(rpm) for rpm in rpms]
             log.info("Considering build idx=%r, (%i of %i) with %r" % (
-                build['build_id'], i, len(builds), rpms))
+                working_build_id, i, len(builds), rpms))
 
             relationships = list(self._yield_koji_relationships_from_build(
-                self.koji_url, build['build_id'], rpms=rpms))
+                self.koji_url, working_build_id, rpms=rpms))
 
             # Reset our loop variables.
             rpms = []

--- a/pdcupdater/handlers/depchain/base.py
+++ b/pdcupdater/handlers/depchain/base.py
@@ -1,0 +1,246 @@
+import collections
+import logging
+import time
+
+import pdcupdater.handlers
+import pdcupdater.services
+from pdcupdater.utils import (
+    tag2release,
+)
+
+
+log = logging.getLogger(__name__)
+
+
+class BaseKojiDepChainHandler(pdcupdater.handlers.BaseHandler):
+    """ Abstract base class. """
+
+    # A list of the types of relationships this thing manages.
+    # This needs to be overridden by subclasses of this base class.
+    managed_types = None
+
+    def _yield_koji_relationships_from_build(self, koji_url, build_id, rpms=None):
+        raise NotImplementedError("Subclasses must implement this.")
+
+    def interesting_tags(self):
+        raise NotImplementedError("Subclasses must implement this.")
+
+    def __init__(self, *args, **kwargs):
+        super(BaseKojiDepChainHandler, self).__init__(*args, **kwargs)
+        self.koji_url = self.config['pdcupdater.koji_url']
+        self.io_threads = self.config.get('pdcupdater.koji_io_threads', 8)
+
+    @property
+    def topic_suffixes(self):
+        return ['buildsys.tag']
+
+    def can_handle(self, msg):
+        if not any([msg['topic'].endswith(suffix)
+                    for suffix in self.topic_suffixes]):
+            return False
+
+        # Ignore secondary arches for now
+        if msg['msg']['instance'] != 'primary':
+            log.debug("From %r.  Skipping." % (msg['msg']['instance']))
+            return False
+
+        interesting = self.interesting_tags()
+        tag = msg['msg']['tag']
+
+        if tag not in interesting:
+            log.debug("%r not in %r.  Skipping."  % (tag, interesting))
+            return False
+
+        return True
+
+    def _yield_managed_pdc_relationships_from_release(self, pdc, release_id):
+        for relationship_type in self.managed_types:
+            entries = pdc.get_paged(
+                pdc['release-component-relationships']._,
+                from_component_release=release_id,
+                type=relationship_type,
+            )
+            for entry in entries:
+                # Filter out any irrelevant relationships (those of some type
+                # managed by a different pdc updater Handler).
+                relationship_type = entry['type']
+                if relationship_type not in self.managed_types:
+                    continue
+
+                # Construct and yield a three-tuple result.
+                keys = ('name', 'release')
+                parent = dict(zip(keys, [entry['from_component'][key] for key in keys]))
+                child = dict(zip(keys, [entry['to_component'][key] for key in keys]))
+                yield parent, relationship_type, child
+
+    def _yield_koji_relationships_from_tag(self, pdc, tag):
+
+        release_id, release = tag2release(tag)
+        # TODO -- this tag <-> release agreement is going to break down with modularity.
+
+        pdcupdater.utils.ensure_release_exists(pdc, release_id, release)
+
+        builds = pdcupdater.services.koji_builds_in_tag(self.koji_url, tag)
+
+        working_build_id = None
+        rpms = []
+        for i, build in enumerate(builds):
+            if not working_build_id:
+                working_build_id = build['build_id']
+
+            if working_build_id == build['build_id']:
+                rpms.append(build)
+                if i != len(builds) - 1:
+                    continue
+
+            def _format_rpm_filename(build):
+                # XXX - do we need to handle epoch here?  I don't think so.
+                return "{name}-{version}-{release}.{arch}.rpm".format(**build)
+
+            rpms = [_format_rpm_filename(rpm) for rpm in rpms]
+            log.info("Considering build idx=%r, (%i of %i) with %r" % (
+                build['build_id'], i, len(builds), rpms))
+
+            relationships = list(self._yield_koji_relationships_from_build(
+                self.koji_url, build['build_id'], rpms=rpms))
+
+            # Reset our loop variables.
+            rpms = []
+            working_build_id = build['build_id']
+
+            for parent_name, relationship_type, child_name in relationships:
+                parent = {
+                    'name': parent_name,
+                    'release': release_id,
+                    #'global_component': build['srpm_name'],  # ideally.
+                }
+                child = {
+                    'name': child_name,
+                    'release': release_id,
+                }
+                yield parent, relationship_type, child
+
+    def handle(self, pdc, msg):
+        tag = msg['msg']['tag']
+        release_id, release = tag2release(tag)
+
+        # TODO -- this tag <-> release agreement is going to break down with modularity.
+        pdcupdater.utils.ensure_release_exists(pdc, release_id, release)
+
+        build_id = msg['msg']['build_id']
+
+        # Go to sleep due to a race condition that is koji's fault.
+        # It publishes a fedmsg message before the task is actually done and
+        # committed to their database.  In the next step, we try to query
+        # them -- but if the task isn't done, we get an exception.
+        #
+        # Here's the koji branch that has some code which will ultimately let
+        # us get rid of this sleep statement:
+        # https://github.com/mikem23/koji-playground/commits/post-commit-callback
+        time.sleep(1)
+
+        # We're going to do things in terms of bulk operations, so first find
+        # all the relationships from koji, then find all the relationships from
+        # pdc.  We'll study the intersection between the two sets and act on
+        # the discrepancies.
+        log.info("Gathering relationships from koji for %r" % build_id)
+        koji_relationships = set(self._yield_koji_relationships_from_build(
+            self.koji_url, build_id))
+
+        # Consolidate those by the parent/from_component
+        by_parent = collections.defaultdict(set)
+        for parent_name, relationship, child_name in koji_relationships:
+            by_parent[parent_name].add((relationship, child_name,))
+
+        # Finally, iterate over all those, now grouped by parent_name
+        for parent_name, koji_relationships in by_parent.items():
+            # TODO -- pass in global_component_name to this function?
+            parent = pdcupdater.utils.ensure_release_component_exists(pdc, release_id, parent_name)
+
+            log.info("Gathering from pdc for %s/%s" % (parent_name, release_id))
+            pdc_relationships = set(self._yield_pdc_relationships_from_build(
+                pdc, parent['name'], release_id))
+
+            to_be_created = koji_relationships - pdc_relationships
+            to_be_deleted = pdc_relationships - koji_relationships
+
+            log.info("Issuing bulk create for %i entries" % len(to_be_created))
+            pdcupdater.utils.ensure_bulk_release_component_relationships_exists(
+                pdc, parent, to_be_created, component_type='rpm')
+
+            log.info("Issuing bulk delete for %i entries" % len(to_be_deleted))
+            pdcupdater.utils.delete_bulk_release_component_relationships(
+                pdc, parent, to_be_deleted)
+
+    def audit(self, pdc):
+        present, absent = set(), set()
+        tags = self.interesting_tags()
+
+        for tag in tags:
+            log.info("Starting audit of tag %r of %r." % (tag, tags))
+            release_id, release = tag2release(tag)
+
+            # Query Koji and PDC to figure out their respective opinions
+            koji_relationships = list(self._yield_koji_relationships_from_tag(pdc, tag))
+            pdc_relationships = list(self._yield_managed_pdc_relationships_from_release(pdc, release_id))
+
+            # normalize the two lists, and smash items into hashable strings.
+            def _format(parent, relationship_type, child):
+                return "%s/%s %s %s/%s" % (
+                    parent['name'], parent['release'],
+                    relationship_type,
+                    child['name'], child['release'],
+                )
+            koji_relationships = set([_format(*x) for x in koji_relationships])
+            pdc_relationships = set([_format(*x) for x in pdc_relationships])
+
+            # use set operators to determine the difference
+            present = present.union(pdc_relationships - koji_relationships)
+            absent = absent.union(koji_relationships - pdc_relationships)
+
+        return present, absent
+
+    def initialize(self, pdc):
+        tags = self.interesting_tags()
+        tags.reverse()
+
+        for tag in tags:
+            log.info("Starting initialize of tag %r of %r." % (tag, tags))
+            release_id, release = tag2release(tag)
+            pdcupdater.utils.ensure_release_exists(pdc, release_id, release)
+
+            # Figure out everything that koji knows about this tag.
+            koji_relationships = self._yield_koji_relationships_from_tag(pdc, tag)
+
+            # Consolidate those by the parent/from_component
+            children = []
+            old_parent = None
+            for parent, relationship, child in koji_relationships:
+                # This only gets triggered the first time through the loop.
+                if not old_parent:
+                    old_parent = parent
+
+                # If switching to a new parent key, then issue bulk create
+                # statements for each parent
+                if parent != old_parent:
+                    pdcupdater.utils.ensure_bulk_release_component_relationships_exists(
+                        pdc, parent, children, component_type='rpm')
+                    # Reset things...
+                    children = []
+                    old_parent = parent
+
+                children.append((relationship, child['name'],))
+
+    def _yield_pdc_relationships_from_build(self, pdc, name, release):
+        for relationship_type in self.managed_types:
+            entries = pdc.get_paged(
+                pdc['release-component-relationships']._,
+                from_component_name=name,
+                from_component_release=release,
+                type=relationship_type,
+            )
+            for entry in entries:
+                # Filter out unmanaged types (just to be sure..)
+                if entry['type'] not in self.managed_types:
+                    continue
+                yield entry['type'], entry['to_component']['name']

--- a/pdcupdater/handlers/depchain/base.py
+++ b/pdcupdater/handlers/depchain/base.py
@@ -90,7 +90,7 @@ class BaseKojiDepChainHandler(pdcupdater.handlers.BaseHandler):
 
         pdcupdater.utils.ensure_release_exists(pdc, release_id, release)
 
-        builds = pdcupdater.services.koji_builds_in_tag(self.koji_url, tag)
+        builds = pdcupdater.services.koji_rpms_in_tag(self.koji_url, tag)
 
         working_build_id = None
         rpms = []

--- a/pdcupdater/handlers/depchain/containers.py
+++ b/pdcupdater/handlers/depchain/containers.py
@@ -67,6 +67,8 @@ class ContainerRPMInclusionDepChainHandler(BaseKojiDepChainHandler):
     def _yield_koji_relationships_from_build(self, koji_url, build_id, rpms=None):
 
         build = pdcupdater.services.koji_get_build(koji_url, build_id)
+        if not build:
+            raise ValueError("Unable to find build %r" % build_id)
         parent = build['name']
 
         artifacts = pdcupdater.services.koji_archives_from_build(

--- a/pdcupdater/handlers/depchain/containers.py
+++ b/pdcupdater/handlers/depchain/containers.py
@@ -1,0 +1,57 @@
+""" Handlers for a container dependency chain model.
+
+Here we're interesting in storing two thing:
+
+- What rpms are installed in a given container.
+- What container images depend on what other container images.
+
+The MetaXOR project (and lb) duplicate some of this work.  Ideally, we would
+both produce caches of the authoritative information stored in koji and OSBS,
+but we could write an audit script to compare and alert if there's a
+difference.
+
+"""
+
+import logging
+
+import pdcupdater.handlers
+import pdcupdater.services
+import pdcupdater.utils
+
+from pdcupdater.handlers.depchain.base import BaseKojiDepChainHandler
+
+
+log = logging.getLogger(__name__)
+
+
+class ContainerRPMInclusionDepChainHandler(BaseKojiDepChainHandler):
+    """ When a container build gets tagged, update PDC with rpm info. """
+
+    # A list of the types of relationships this thing manages.
+    managed_types = ('ContainerIncludesRPM',)
+
+    def interesting_tags(self):
+        return pdcupdater.utils.interesting_container_tags()
+
+    def _yield_koji_relationships_from_build(self, koji_url, build_id, rpms=None):
+
+        # TODO -- s/rpms/artifacts/g
+        artifacts = rpms
+
+        build = pdcupdater.services.koji_get_build(koji_url, build_id)
+        parent = build['name']
+
+        # Get all artifacts for a build... only if they're not supplied.
+        if not artifacts:
+            artifacts = pdcupdater.services.koji_archives_from_build(
+                koji_url, build_id)
+
+        for artifact in artifacts:
+            if artifact['type_name'] in ('ks', 'cfg', 'xml'):
+                continue
+            log.debug("Looking up installed rpms for %r" % artifact['filename'])
+            rpms = pdcupdater.services.koji_rpms_from_archive(self.koji_url, artifact)
+            for entry in rpms:
+                child = entry['name']
+                # TODO - do some checks about external repos here...
+                yield parent, 'ContainerIncludesRPM', child

--- a/pdcupdater/handlers/depchain/containers.py
+++ b/pdcupdater/handlers/depchain/containers.py
@@ -1,6 +1,6 @@
 """ Handlers for a container dependency chain model.
 
-Here we're interesting in storing two thing:
+Here we're interested in storing two thing:
 
 - What rpms are installed in a given container.
 - What container images depend on what other container images.

--- a/pdcupdater/handlers/depchain/containers.py
+++ b/pdcupdater/handlers/depchain/containers.py
@@ -29,6 +29,9 @@ class ContainerRPMInclusionDepChainHandler(BaseKojiDepChainHandler):
 
     # A list of the types of relationships this thing manages.
     managed_types = ('ContainerIncludesRPM',)
+    # The types of the parents and children in our managed relationships
+    parent_type = 'container'
+    child_type = 'rpm'
 
     def interesting_tags(self):
         return pdcupdater.utils.interesting_container_tags()

--- a/pdcupdater/handlers/depchain/rpms.py
+++ b/pdcupdater/handlers/depchain/rpms.py
@@ -29,6 +29,9 @@ class NewRPMBuildTimeDepChainHandler(BaseKojiDepChainHandler):
 
     # A list of the types of relationships this thing manages.
     managed_types = ('RPMBuildRequires', 'RPMBuildRoot')
+    # The types of the parents and children in our managed relationships
+    parent_type = 'rpm'
+    child_type = 'rpm'
 
     def interesting_tags(self):
         return pdcupdater.utils.interesting_tags()
@@ -76,6 +79,9 @@ class NewRPMRunTimeDepChainHandler(BaseKojiDepChainHandler):
 
     # A list of the types of relationships this thing manages.
     managed_types = ('RPMRequires',)
+    # The types of the parents and children in our managed relationships
+    parent_type = 'rpm'
+    child_type = 'rpm'
 
     def interesting_tags(self):
         return pdcupdater.utils.interesting_tags()

--- a/pdcupdater/handlers/depchain/rpms.py
+++ b/pdcupdater/handlers/depchain/rpms.py
@@ -13,255 +13,25 @@ PDC with that.
 import collections
 import logging
 import multiprocessing.pool
-import time
 
 import pdcupdater.handlers
 import pdcupdater.services
-from pdcupdater.utils import (
-    tag2release,
-    interesting_tags,
-)
+import pdcupdater.utils
+
+from pdcupdater.handlers.depchain.base import BaseKojiDepChainHandler
 
 
 log = logging.getLogger(__name__)
 
 
-class BaseRPMDepChainHandler(pdcupdater.handlers.BaseHandler):
-    """ Abstract base class. """
-
-    # A list of the types of relationships this thing manages.
-    # This needs to be overridden by subclasses of this base class.
-    managed_types = None
-
-    def _yield_koji_relationships_from_build(self, koji_url, build_id, rpms=None):
-        raise NotImplementedError("Subclasses must implement this.")
-
-    def __init__(self, *args, **kwargs):
-        super(BaseRPMDepChainHandler, self).__init__(*args, **kwargs)
-        self.koji_url = self.config['pdcupdater.koji_url']
-        self.io_threads = self.config.get('pdcupdater.koji_io_threads', 8)
-
-    @property
-    def topic_suffixes(self):
-        return ['buildsys.tag']
-
-    def can_handle(self, msg):
-        if not any([msg['topic'].endswith(suffix)
-                    for suffix in self.topic_suffixes]):
-            return False
-
-        # Ignore secondary arches for now
-        if msg['msg']['instance'] != 'primary':
-            log.debug("From %r.  Skipping." % (msg['msg']['instance']))
-            return False
-
-        interesting = interesting_tags()
-        tag = msg['msg']['tag']
-
-        if tag not in interesting:
-            log.debug("%r not in %r.  Skipping."  % (tag, interesting))
-            return False
-
-        return True
-
-    def _yield_managed_pdc_relationships_from_release(self, pdc, release_id):
-        for relationship_type in self.managed_types:
-            entries = pdc.get_paged(
-                pdc['release-component-relationships']._,
-                from_component_release=release_id,
-                type=relationship_type,
-            )
-            for entry in entries:
-                # Filter out any irrelevant relationships (those of some type
-                # managed by a different pdc updater Handler).
-                relationship_type = entry['type']
-                if relationship_type not in self.managed_types:
-                    continue
-
-                # Construct and yield a three-tuple result.
-                keys = ('name', 'release')
-                parent = dict(zip(keys, [entry['from_component'][key] for key in keys]))
-                child = dict(zip(keys, [entry['to_component'][key] for key in keys]))
-                yield parent, relationship_type, child
-
-    def _yield_koji_relationships_from_tag(self, pdc, tag):
-
-        release_id, release = tag2release(tag)
-        # TODO -- this tag <-> release agreement is going to break down with modularity.
-
-        pdcupdater.utils.ensure_release_exists(pdc, release_id, release)
-
-        builds = pdcupdater.services.koji_builds_in_tag(self.koji_url, tag)
-
-        working_build_id = None
-        rpms = []
-        for i, build in enumerate(builds):
-            if not working_build_id:
-                working_build_id = build['build_id']
-
-            if working_build_id == build['build_id']:
-                rpms.append(build)
-                if i != len(builds) - 1:
-                    continue
-
-            def _format_rpm_filename(build):
-                # XXX - do we need to handle epoch here?  I don't think so.
-                return "{name}-{version}-{release}.{arch}.rpm".format(**build)
-
-            rpms = [_format_rpm_filename(rpm) for rpm in rpms]
-            log.info("Considering build idx=%r, (%i of %i) with %r" % (
-                build['build_id'], i, len(builds), rpms))
-
-            relationships = list(self._yield_koji_relationships_from_build(
-                self.koji_url, build['build_id'], rpms=rpms))
-
-            # Reset our loop variables.
-            rpms = []
-            working_build_id = build['build_id']
-
-            for parent_name, relationship_type, child_name in relationships:
-                parent = {
-                    'name': parent_name,
-                    'release': release_id,
-                    #'global_component': build['srpm_name'],  # ideally.
-                }
-                child = {
-                    'name': child_name,
-                    'release': release_id,
-                }
-                yield parent, relationship_type, child
-
-    def handle(self, pdc, msg):
-        tag = msg['msg']['tag']
-        release_id, release = tag2release(tag)
-
-        # TODO -- this tag <-> release agreement is going to break down with modularity.
-        pdcupdater.utils.ensure_release_exists(pdc, release_id, release)
-
-        build_id = msg['msg']['build_id']
-
-        # Go to sleep due to a race condition that is koji's fault.
-        # It publishes a fedmsg message before the task is actually done and
-        # committed to their database.  In the next step, we try to query
-        # them -- but if the task isn't done, we get an exception.
-        #
-        # Here's the koji branch that has some code which will ultimately let
-        # us get rid of this sleep statement:
-        # https://github.com/mikem23/koji-playground/commits/post-commit-callback
-        time.sleep(1)
-
-        # We're going to do things in terms of bulk operations, so first find
-        # all the relationships from koji, then find all the relationships from
-        # pdc.  We'll study the intersection between the two sets and act on
-        # the discrepancies.
-        log.info("Gathering relationships from koji for %r" % build_id)
-        koji_relationships = set(self._yield_koji_relationships_from_build(
-            self.koji_url, build_id))
-
-        # Consolidate those by the parent/from_component
-        by_parent = collections.defaultdict(set)
-        for parent_name, relationship, child_name in koji_relationships:
-            by_parent[parent_name].add((relationship, child_name,))
-
-        # Finally, iterate over all those, now grouped by parent_name
-        for parent_name, koji_relationships in by_parent.items():
-            # TODO -- pass in global_component_name to this function?
-            parent = pdcupdater.utils.ensure_release_component_exists(pdc, release_id, parent_name)
-
-            log.info("Gathering from pdc for %s/%s" % (parent_name, release_id))
-            pdc_relationships = set(self._yield_pdc_relationships_from_build(
-                pdc, parent['name'], release_id))
-
-            to_be_created = koji_relationships - pdc_relationships
-            to_be_deleted = pdc_relationships - koji_relationships
-
-            log.info("Issuing bulk create for %i entries" % len(to_be_created))
-            pdcupdater.utils.ensure_bulk_release_component_relationships_exists(
-                pdc, parent, to_be_created, component_type='rpm')
-
-            log.info("Issuing bulk delete for %i entries" % len(to_be_deleted))
-            pdcupdater.utils.delete_bulk_release_component_relationships(
-                pdc, parent, to_be_deleted)
-
-    def audit(self, pdc):
-        present, absent = set(), set()
-        tags = interesting_tags()
-
-        for tag in tags:
-            log.info("Starting audit of tag %r of %r." % (tag, tags))
-            release_id, release = tag2release(tag)
-
-            # Query Koji and PDC to figure out their respective opinions
-            koji_relationships = list(self._yield_koji_relationships_from_tag(pdc, tag))
-            pdc_relationships = list(self._yield_managed_pdc_relationships_from_release(pdc, release_id))
-
-            # normalize the two lists, and smash items into hashable strings.
-            def _format(parent, relationship_type, child):
-                return "%s/%s %s %s/%s" % (
-                    parent['name'], parent['release'],
-                    relationship_type,
-                    child['name'], child['release'],
-                )
-            koji_relationships = set([_format(*x) for x in koji_relationships])
-            pdc_relationships = set([_format(*x) for x in pdc_relationships])
-
-            # use set operators to determine the difference
-            present = present.union(pdc_relationships - koji_relationships)
-            absent = absent.union(koji_relationships - pdc_relationships)
-
-        return present, absent
-
-    def initialize(self, pdc):
-        tags = interesting_tags()
-        tags.reverse()
-
-        for tag in tags:
-            log.info("Starting initialize of tag %r of %r." % (tag, tags))
-            release_id, release = tag2release(tag)
-            pdcupdater.utils.ensure_release_exists(pdc, release_id, release)
-
-            # Figure out everything that koji knows about this tag.
-            koji_relationships = self._yield_koji_relationships_from_tag(pdc, tag)
-
-            # Consolidate those by the parent/from_component
-            children = []
-            old_parent = None
-            for parent, relationship, child in koji_relationships:
-                # This only gets triggered the first time through the loop.
-                if not old_parent:
-                    old_parent = parent
-
-                # If switching to a new parent key, then issue bulk create
-                # statements for each parent
-                if parent != old_parent:
-                    pdcupdater.utils.ensure_bulk_release_component_relationships_exists(
-                        pdc, parent, children, component_type='rpm')
-                    # Reset things...
-                    children = []
-                    old_parent = parent
-
-                children.append((relationship, child['name'],))
-
-    def _yield_pdc_relationships_from_build(self, pdc, name, release):
-        for relationship_type in self.managed_types:
-            entries = pdc.get_paged(
-                pdc['release-component-relationships']._,
-                from_component_name=name,
-                from_component_release=release,
-                type=relationship_type,
-            )
-            for entry in entries:
-                # Filter out unmanaged types (just to be sure..)
-                if entry['type'] not in self.managed_types:
-                    continue
-                yield entry['type'], entry['to_component']['name']
-
-
-class NewRPMBuildTimeDepChainHandler(BaseRPMDepChainHandler):
+class NewRPMBuildTimeDepChainHandler(BaseKojiDepChainHandler):
     """ When a build gets tagged, update PDC with buildroot info. """
 
     # A list of the types of relationships this thing manages.
     managed_types = ('RPMBuildRequires', 'RPMBuildRoot')
+
+    def interesting_tags(self):
+        return pdcupdater.utils.interesting_tags()
 
     def _yield_koji_relationships_from_build(self, koji_url, build_id, rpms=None):
 
@@ -301,11 +71,14 @@ class NewRPMBuildTimeDepChainHandler(BaseRPMDepChainHandler):
                 yield parent, relationship_type, child
 
 
-class NewRPMRunTimeDepChainHandler(BaseRPMDepChainHandler):
+class NewRPMRunTimeDepChainHandler(BaseKojiDepChainHandler):
     """ When a build gets tagged, update PDC with rpm dep info. """
 
     # A list of the types of relationships this thing manages.
     managed_types = ('RPMRequires',)
+
+    def interesting_tags(self):
+        return pdcupdater.utils.interesting_tags()
 
     def _yield_koji_relationships_from_build(self, koji_url, build_id, rpms=None):
 

--- a/pdcupdater/handlers/rpms.py
+++ b/pdcupdater/handlers/rpms.py
@@ -102,7 +102,7 @@ class NewRPMHandler(pdcupdater.handlers.BaseHandler):
 
     def _gather_koji_rpms(self):
         koji_rpms = {
-            tag: pdcupdater.services.koji_builds_in_tag(self.koji_url, tag)
+            tag: pdcupdater.services.koji_rpms_in_tag(self.koji_url, tag)
             for tag in interesting_tags()
         }
 

--- a/pdcupdater/services.py
+++ b/pdcupdater/services.py
@@ -163,12 +163,33 @@ def koji_builds_in_tag(url, tag):
 
 
 @cache.cache_on_arguments()
+def koji_get_build(url, build_id):
+    import koji
+    session = koji.ClientSession(url)
+    return session.getBuild(build_id)
+
+
+@cache.cache_on_arguments()
+def koji_archives_from_build(url, build_id):
+    import koji
+    session = koji.ClientSession(url)
+    return session.listArchives(build_id)
+
+
+@cache.cache_on_arguments()
+def koji_rpms_from_archive(url, artifact):
+    import koji
+    session = koji.ClientSession(url)
+    return session.listRPMs(imageID=artifact.get('id'))
+
+
+@cache.cache_on_arguments()
 @pdcupdater.utils.retry()
 def koji_rpms_from_build(url, build_id):
     import koji
     log.info("Listing rpms in koji(%s) for %r" % (url, build_id))
     session = koji.ClientSession(url)
-    build = session.getBuild(build_id)
+    build = koji_get_build(url, build_id)
     children = session.getTaskChildren(build['task_id'])
 
     rpms = set()

--- a/pdcupdater/services.py
+++ b/pdcupdater/services.py
@@ -166,7 +166,10 @@ def koji_builds_in_tag(url, tag):
 def koji_get_build(url, build_id):
     import koji
     session = koji.ClientSession(url)
-    return session.getBuild(build_id)
+    build = session.getBuild(build_id)
+    if build:
+        assert build['id'] == build_id, "%r != %r" % (build['id'], build_id)
+    return build
 
 
 @cache.cache_on_arguments()

--- a/pdcupdater/services.py
+++ b/pdcupdater/services.py
@@ -145,7 +145,7 @@ def koji_yield_rpm_requires(url, nvra):
 
 
 @pdcupdater.utils.retry()
-def koji_builds_in_tag(url, tag):
+def koji_rpms_in_tag(url, tag):
     """ Return the list of koji builds in a tag. """
     import koji
     log.info("Listing rpms in koji(%s) tag %s" % (url, tag))

--- a/pdcupdater/services.py
+++ b/pdcupdater/services.py
@@ -144,9 +144,18 @@ def koji_yield_rpm_requires(url, nvra):
         yield dep['name'], qualifier, dep['version'].rstrip()
 
 
+#@pdcupdater.utils.retry()
+def koji_builds_in_tag(url, tag):
+    """ Return the list of koji builds in a tag. """
+    import koji
+    log.info("Listing rpms in koji(%s) tag %s" % (url, tag))
+    session = koji.ClientSession(url)
+    return session.listTagged(tag, latest=True)
+
+
 @pdcupdater.utils.retry()
 def koji_rpms_in_tag(url, tag):
-    """ Return the list of koji builds in a tag. """
+    """ Return the list of koji rpms in a tag. """
     import koji
     log.info("Listing rpms in koji(%s) tag %s" % (url, tag))
     session = koji.ClientSession(url)

--- a/pdcupdater/tests/handler_tests/__init__.py
+++ b/pdcupdater/tests/handler_tests/__init__.py
@@ -57,6 +57,7 @@ def mock_pdc(function):
         pdc.add_endpoint('releases/fedora-26', 'GET', {})
         pdc.add_endpoint('releases/fedora-25', 'GET', {})
         pdc.add_endpoint('releases/fedora-24', 'GET', {})
+        pdc.add_endpoint('releases/fedora-24-updates', 'GET', {})
         pdc.add_endpoint('releases/fedora-23-updates', 'GET', {})
         pdc.add_endpoint('releases/fedora-22-updates', 'GET', {})
         pdc.add_endpoint('releases/fedora-21-updates', 'GET', {})

--- a/pdcupdater/tests/handler_tests/test_depchain_containers.py
+++ b/pdcupdater/tests/handler_tests/test_depchain_containers.py
@@ -1,0 +1,190 @@
+import mock
+
+import pdcupdater.utils
+from pdcupdater.tests.handler_tests import (
+    BaseHandlerTest, mock_pdc
+)
+
+
+class TestInclusionDepIngestion(BaseHandlerTest):
+    maxDiff = None
+    handler_path = 'pdcupdater.handlers.depchain.containers:ContainerRPMInclusionDepChainHandler'
+    config = {}
+
+    @mock.patch('pdcupdater.utils.rawhide_tag')
+    @mock.patch('pdcupdater.utils.interesting_container_tags')
+    def test_can_handle_buildsys_tag_message(self, tags, rawhide):
+        tags.return_value = ['f24-docker']
+        rawhide.return_value = 'f24'
+        idx = '2016-b78e670b-e8f7-4987-868e-1260cc0f3fbd'
+        msg = pdcupdater.utils.get_fedmsg(idx)
+        result = self.handler.can_handle(msg)
+        self.assertEquals(result, True)
+
+    @mock_pdc
+    @mock.patch('pdcupdater.utils.rawhide_tag')
+    @mock.patch('pdcupdater.utils.interesting_container_tags')
+    @mock.patch('pdcupdater.services.koji_rpms_from_archive')
+    @mock.patch('pdcupdater.services.koji_archives_from_build')
+    @mock.patch('pdcupdater.services.koji_get_build')
+    def test_handle_new_build(self, pdc, get_build, archives, rpms, tags, rawhide):
+        tags.return_value = ['f24']
+        rawhide.return_value = 'f24'
+        container_build = {
+            'build_id': 'fake_build_id',
+            'name': 'cockpit', 'version': 1, 'release': 2, 'arch': 'foo',
+        }
+        rpm_build = {
+            'build_id': 'fake_build_id',
+            'name': 'guake', 'version': 1, 'release': 2, 'arch': 'foo',
+        }
+        get_build.return_value = container_build
+        archives.return_value = [{
+            'build_id': 802427,
+            'buildroot_id': 6459519,
+            'checksum': 'bf81b182dfbbf331ddd5700327abb4fe',
+            'checksum_type': 0,
+            'extra': 'stuff goes here...',
+            'filename': 'docker-image-e3be590239f.x86_64.tar.gz',
+            'id': 14707,
+            'metadata_only': False,
+            'size': 199457398,
+            'type_description': 'Tar files',
+            'type_extensions': 'tar tar.gz tar.bz2 tar.xz',
+            'type_id': 4,
+            'type_name': 'tar',
+        }]
+        rpms.return_value = [rpm_build]
+
+        idx = '2016-b78e670b-e8f7-4987-868e-1260cc0f3fbd'
+        msg = pdcupdater.utils.get_fedmsg(idx)
+        self.handler.handle(pdc, msg)
+        expected_keys = [
+            'release-component-relationships',
+            'releases/fedora-24-updates',
+            'release-components',
+            'global-components',
+        ]
+        self.assertEquals(pdc.calls.keys(), expected_keys)
+
+        self.assertEqual(len(pdc.calls['global-components']), 1)
+        self.assertEqual(len(pdc.calls['release-components']), 1)
+        self.assertEqual(len(pdc.calls['release-component-relationships']), 2)
+
+    @mock_pdc
+    @mock.patch('pdcupdater.utils.rawhide_tag')
+    @mock.patch('pdcupdater.utils.interesting_tags')
+    @mock.patch('pdcupdater.services.koji_rpms_from_archive')
+    @mock.patch('pdcupdater.services.koji_archives_from_build')
+    @mock.patch('pdcupdater.services.koji_builds_in_tag')
+    @mock.patch('pdcupdater.services.koji_get_build')
+    def test_audit_empty_koji(self, pdc, get_build, builds, archives, rpms, tags, rawhide):
+        tags.return_value = ['f24']
+        rawhide.return_value = 'f24'
+
+        # Mock out koji results
+        build = {
+            'build_id': 'fake_build_id',
+            'name': 'guake',
+            'version': 1,
+            'release': 2,
+            'arch': 'foo',
+        }
+        get_build.return_value = build
+        builds.return_value = [build]
+        archives.return_value = [{
+            'build_id': 802427,
+            'buildroot_id': 6459519,
+            'checksum': 'bf81b182dfbbf331ddd5700327abb4fe',
+            'checksum_type': 0,
+            'extra': 'stuff goes here...',
+            'filename': 'docker-image-e3be590239f.x86_64.tar.gz',
+            'id': 14707,
+            'metadata_only': False,
+            'size': 199457398,
+            'type_description': 'Tar files',
+            'type_extensions': 'tar tar.gz tar.bz2 tar.xz',
+            'type_id': 4,
+            'type_name': 'tar'}
+        ]
+        rpms.return_value = []
+
+        # Call the auditor
+        present, absent = self.handler.audit(pdc)
+
+        # Check the PDC calls..
+        self.assertDictEqual(pdc.calls, {
+            'release-component-relationships': [
+                ('GET', {
+                    'page': 1,
+                    'from_component_release': 'fedora-24-updates',
+                    'type': 'ContainerIncludesRPM',
+                }),
+            ],
+            'releases/fedora-24-updates': [('GET', {})]
+        })
+
+        # Check the results.
+        self.assertSetEqual(present, set())
+        self.assertSetEqual(absent, set())
+
+
+    @mock_pdc
+    @mock.patch('pdcupdater.utils.rawhide_tag')
+    @mock.patch('pdcupdater.utils.interesting_tags')
+    @mock.patch('pdcupdater.services.koji_rpms_from_archive')
+    @mock.patch('pdcupdater.services.koji_archives_from_build')
+    @mock.patch('pdcupdater.services.koji_builds_in_tag')
+    @mock.patch('pdcupdater.services.koji_get_build')
+    def test_audit_mismatch(self, pdc, get_build, builds, archives, rpms, tags, rawhide):
+        tags.return_value = ['f24']
+        rawhide.return_value = 'f24'
+
+        # Mock out koji results
+        container_build = {
+            'build_id': 'fake_build_id',
+            'name': 'cockpit', 'version': 1, 'release': 2, 'arch': 'foo',
+        }
+        rpm_build = {
+            'build_id': 'fake_build_id',
+            'name': 'guake', 'version': 1, 'release': 2, 'arch': 'foo',
+        }
+        get_build.return_value = container_build
+        builds.return_value = [container_build]
+        archives.return_value = [{
+            'build_id': 802427,
+            'buildroot_id': 6459519,
+            'checksum': 'bf81b182dfbbf331ddd5700327abb4fe',
+            'checksum_type': 0,
+            'extra': 'stuff goes here...',
+            'filename': 'docker-image-e3be590239f.x86_64.tar.gz',
+            'id': 14707,
+            'metadata_only': False,
+            'size': 199457398,
+            'type_description': 'Tar files',
+            'type_extensions': 'tar tar.gz tar.bz2 tar.xz',
+            'type_id': 4,
+            'type_name': 'tar'}
+        ]
+        rpms.return_value = [rpm_build]
+
+        # Call the auditor
+        present, absent = self.handler.audit(pdc)
+
+        # Check the PDC calls..
+        self.assertDictEqual(pdc.calls, {
+            'release-component-relationships': [
+                ('GET', {
+                    'page': 1,
+                    'from_component_release': 'fedora-24-updates',
+                    'type': 'ContainerIncludesRPM',
+                }),
+            ],
+            'releases/fedora-24-updates': [('GET', {})]
+        })
+
+        # Check the results.
+        self.assertSetEqual(present, set([]))
+        self.assertSetEqual(absent, set([
+            'cockpit/fedora-24-updates ContainerIncludesRPM guake/fedora-24-updates',
+        ]))

--- a/pdcupdater/tests/handler_tests/test_depchain_rpms.py
+++ b/pdcupdater/tests/handler_tests/test_depchain_rpms.py
@@ -43,9 +43,9 @@ class TestBuildtimeDepIngestion(BaseHandlerTest):
         ]
         self.assertEquals(pdc.calls.keys(), expected_keys)
 
-        self.assertEqual(len(pdc.calls['global-components']), 22)
-        self.assertEqual(len(pdc.calls['release-components']), 22)
-        self.assertEqual(len(pdc.calls['release-component-relationships']), 66)
+        self.assertEqual(len(pdc.calls['global-components']), 21)
+        self.assertEqual(len(pdc.calls['release-components']), 21)
+        self.assertEqual(len(pdc.calls['release-component-relationships']), 63)
 
     @mock_pdc
     @mock.patch('pdcupdater.utils.rawhide_tag')

--- a/pdcupdater/tests/handler_tests/test_depchain_rpms.py
+++ b/pdcupdater/tests/handler_tests/test_depchain_rpms.py
@@ -52,7 +52,7 @@ class TestBuildtimeDepIngestion(BaseHandlerTest):
     @mock.patch('pdcupdater.utils.interesting_tags')
     @mock.patch('pdcupdater.services.koji_list_buildroot_for')
     @mock.patch('pdcupdater.services.koji_rpms_from_build')
-    @mock.patch('pdcupdater.services.koji_builds_in_tag')
+    @mock.patch('pdcupdater.services.koji_rpms_in_tag')
     def test_audit_empty_koji(self, pdc, builds, rpms, buildroot, tags, rawhide):
         tags.return_value = ['f24']
         rawhide.return_value = 'f24'
@@ -97,7 +97,7 @@ class TestBuildtimeDepIngestion(BaseHandlerTest):
     @mock.patch('pdcupdater.utils.interesting_tags')
     @mock.patch('pdcupdater.services.koji_list_buildroot_for')
     @mock.patch('pdcupdater.services.koji_rpms_from_build')
-    @mock.patch('pdcupdater.services.koji_builds_in_tag')
+    @mock.patch('pdcupdater.services.koji_rpms_in_tag')
     def test_audit_mismatch(self, pdc, builds, rpms, buildroot, tags, rawhide):
         tags.return_value = ['f24']
         rawhide.return_value = 'f24'
@@ -154,7 +154,7 @@ class TestRuntimeDepIngestion(BaseHandlerTest):
     @mock.patch('pdcupdater.utils.interesting_tags')
     @mock.patch('pdcupdater.services.koji_yield_rpm_requires')
     @mock.patch('pdcupdater.services.koji_rpms_from_build')
-    @mock.patch('pdcupdater.services.koji_builds_in_tag')
+    @mock.patch('pdcupdater.services.koji_rpms_in_tag')
     def test_audit_mismatch(self, pdc, builds, rpms, requires, tags, rawhide):
         tags.return_value = ['f24']
         rawhide.return_value = 'f24'
@@ -193,7 +193,7 @@ class TestRuntimeDepIngestion(BaseHandlerTest):
     @mock.patch('pdcupdater.utils.interesting_tags')
     @mock.patch('pdcupdater.services.koji_yield_rpm_requires')
     @mock.patch('pdcupdater.services.koji_rpms_from_build')
-    @mock.patch('pdcupdater.services.koji_builds_in_tag')
+    @mock.patch('pdcupdater.services.koji_rpms_in_tag')
     def test_audit_simple_match(self, pdc, builds, rpms, requires, tags, rawhide):
         tags.return_value = ['f24']
         rawhide.return_value = 'f24'
@@ -232,7 +232,7 @@ class TestRuntimeDepIngestion(BaseHandlerTest):
     @mock.patch('pdcupdater.utils.interesting_tags')
     @mock.patch('pdcupdater.services.koji_yield_rpm_requires')
     @mock.patch('pdcupdater.services.koji_rpms_from_build')
-    @mock.patch('pdcupdater.services.koji_builds_in_tag')
+    @mock.patch('pdcupdater.services.koji_rpms_in_tag')
     def test_initialize(self, pdc, builds, rpms, requires, tags, rawhide):
         tags.return_value = ['f24']
         rawhide.return_value = 'f24'

--- a/pdcupdater/tests/handler_tests/test_depchain_rpms.py
+++ b/pdcupdater/tests/handler_tests/test_depchain_rpms.py
@@ -12,7 +12,7 @@ class TestBuildtimeDepIngestion(BaseHandlerTest):
     config = {}
 
     @mock.patch('pdcupdater.utils.rawhide_tag')
-    @mock.patch('pdcupdater.handlers.depchain.rpms.interesting_tags')
+    @mock.patch('pdcupdater.utils.interesting_tags')
     def test_can_handle_buildsys_tag_message(self, tags, rawhide):
         tags.return_value = ['f24']
         rawhide.return_value = 'f24'
@@ -24,7 +24,7 @@ class TestBuildtimeDepIngestion(BaseHandlerTest):
     @mock_pdc
     @mock.patch('pdcupdater.services.koji_list_buildroot_for')
     @mock.patch('pdcupdater.utils.rawhide_tag')
-    @mock.patch('pdcupdater.handlers.depchain.rpms.interesting_tags')
+    @mock.patch('pdcupdater.utils.interesting_tags')
     def test_handle_new_build(self, pdc, tags, rawhide, buildroot):
         tags.return_value = ['f24']
         rawhide.return_value = 'f24'
@@ -49,7 +49,7 @@ class TestBuildtimeDepIngestion(BaseHandlerTest):
 
     @mock_pdc
     @mock.patch('pdcupdater.utils.rawhide_tag')
-    @mock.patch('pdcupdater.handlers.depchain.rpms.interesting_tags')
+    @mock.patch('pdcupdater.utils.interesting_tags')
     @mock.patch('pdcupdater.services.koji_list_buildroot_for')
     @mock.patch('pdcupdater.services.koji_rpms_from_build')
     @mock.patch('pdcupdater.services.koji_builds_in_tag')
@@ -94,7 +94,7 @@ class TestBuildtimeDepIngestion(BaseHandlerTest):
 
     @mock_pdc
     @mock.patch('pdcupdater.utils.rawhide_tag')
-    @mock.patch('pdcupdater.handlers.depchain.rpms.interesting_tags')
+    @mock.patch('pdcupdater.utils.interesting_tags')
     @mock.patch('pdcupdater.services.koji_list_buildroot_for')
     @mock.patch('pdcupdater.services.koji_rpms_from_build')
     @mock.patch('pdcupdater.services.koji_builds_in_tag')
@@ -151,7 +151,7 @@ class TestRuntimeDepIngestion(BaseHandlerTest):
 
     @mock_pdc
     @mock.patch('pdcupdater.utils.rawhide_tag')
-    @mock.patch('pdcupdater.handlers.depchain.rpms.interesting_tags')
+    @mock.patch('pdcupdater.utils.interesting_tags')
     @mock.patch('pdcupdater.services.koji_yield_rpm_requires')
     @mock.patch('pdcupdater.services.koji_rpms_from_build')
     @mock.patch('pdcupdater.services.koji_builds_in_tag')
@@ -190,7 +190,7 @@ class TestRuntimeDepIngestion(BaseHandlerTest):
 
     @mock_pdc
     @mock.patch('pdcupdater.utils.rawhide_tag')
-    @mock.patch('pdcupdater.handlers.depchain.rpms.interesting_tags')
+    @mock.patch('pdcupdater.utils.interesting_tags')
     @mock.patch('pdcupdater.services.koji_yield_rpm_requires')
     @mock.patch('pdcupdater.services.koji_rpms_from_build')
     @mock.patch('pdcupdater.services.koji_builds_in_tag')
@@ -229,7 +229,7 @@ class TestRuntimeDepIngestion(BaseHandlerTest):
 
     @mock_pdc
     @mock.patch('pdcupdater.utils.rawhide_tag')
-    @mock.patch('pdcupdater.handlers.depchain.rpms.interesting_tags')
+    @mock.patch('pdcupdater.utils.interesting_tags')
     @mock.patch('pdcupdater.services.koji_yield_rpm_requires')
     @mock.patch('pdcupdater.services.koji_rpms_from_build')
     @mock.patch('pdcupdater.services.koji_builds_in_tag')

--- a/pdcupdater/tests/handler_tests/test_rpms.py
+++ b/pdcupdater/tests/handler_tests/test_rpms.py
@@ -267,7 +267,7 @@ class TestNewRPM(BaseHandlerTest):
         })
 
     @mock_pdc
-    @mock.patch('pdcupdater.services.koji_builds_in_tag')
+    @mock.patch('pdcupdater.services.koji_rpms_in_tag')
     def test_initialize_from_koji(self, pdc, koji):
         koji.side_effect = mocked_koji_from_tag
 
@@ -305,7 +305,7 @@ class TestNewRPM(BaseHandlerTest):
         })
 
     @mock_pdc
-    @mock.patch('pdcupdater.services.koji_builds_in_tag')
+    @mock.patch('pdcupdater.services.koji_rpms_in_tag')
     def test_audit(self, pdc, koji):
         # Mock out koji response
         koji.side_effect = mocked_koji_from_tag
@@ -325,7 +325,7 @@ class TestNewRPM(BaseHandlerTest):
         self.assertSetEqual(absent, set())
 
     @mock_pdc
-    @mock.patch('pdcupdater.services.koji_builds_in_tag')
+    @mock.patch('pdcupdater.services.koji_rpms_in_tag')
     def test_audit_missing_one(self, pdc, koji):
         # Mock out koji response
         koji.side_effect = mocked_koji_from_tag_missing_one
@@ -357,7 +357,7 @@ class TestNewRPM(BaseHandlerTest):
         self.assertSetEqual(absent, set())
 
     @mock_pdc
-    @mock.patch('pdcupdater.services.koji_builds_in_tag')
+    @mock.patch('pdcupdater.services.koji_rpms_in_tag')
     def test_audit_adding_one(self, pdc, koji):
         # Mock out koji response
         koji.side_effect = mocked_koji_from_tag_adding_one

--- a/pdcupdater/utils.py
+++ b/pdcupdater/utils.py
@@ -123,13 +123,19 @@ def ensure_release_component_exists(pdc, release_id, name, type='rpm'):
         body = e.response.json()
         if not 'non_field_errors' in body:
             raise
-        message = u'The fields release, name must make a unique set.'
-        if body['non_field_errors'] != [message]:
+        allowable = [
+            # This is the old error string
+            u'The fields release, name must make a unique set.',
+            # This is the new error string, after
+            # https://github.com/product-definition-center/product-definition-center/pull/422
+            u'The fields release, name, type must make a unique set.',
+        ]
+        if not any([body['non_field_errors'] == [s] for s in allowable]):
             raise
 
     # But if it was just that the component already existed, then go back and
     # query for what we tried to submit (return the primary key)
-    query = dict(name=name, release=release_id)
+    query = dict(name=name, release=release_id, type=type)
     response = pdc['release-components']._(**query)
     if not response['count']:
         raise IndexError("No results found for %r after submitting %r" % (

--- a/pdcupdater/utils.py
+++ b/pdcupdater/utils.py
@@ -530,6 +530,14 @@ def tag2release(tag):
             'release_type': 'ga',
         }
         release_id = "{short}-{version}".format(**release)
+    elif tag.endswith('-docker'):
+        release = {
+            'name': 'Fedora Updates',
+            'short': 'fedora',
+            'version': tag.strip('-docker').strip('f'),
+            'release_type': 'updates',
+        }
+        release_id = "{short}-{version}-{release_type}".format(**release)
     else:
         bodhi_info = {r['stable_tag']: r for r in bodhi_releases()}[tag]
         if 'EPEL' in bodhi_info['id_prefix']:

--- a/pdcupdater/utils.py
+++ b/pdcupdater/utils.py
@@ -475,6 +475,18 @@ def interesting_tags():
     return stable_tags + [rawhide_tag()]
 
 
+def interesting_container_tags():
+    """ Returns a list of "interesting tags" relevant to containers.
+
+    Eventually, we should query PDC itself to figure out what tags we should be
+    concerned with.
+    """
+    return ['f24-docker']  # This is all we're producing for now...
+    #tags = interesting_tags()
+    #tags = [tag for tag in tags if '-' not in tag]
+    #return ['%s-docker' % tag for tag in tags]
+
+
 def release2reponame(release):
     """ Convert a PDC release to an mdapi repo name lexicographically. """
     # TODO -- we should be able to do this by querying the pdc releases


### PR DESCRIPTION
This pulls the deps out of koji's API and stores them in PDC.

I ran into product-definition-center/product-definition-center#422 along the way.