### PR TITLE
Optionally use PDC to map tags to releases.

### DIFF
--- a/pdcupdater/handlers/depchain/containers.py
+++ b/pdcupdater/handlers/depchain/containers.py
@@ -38,7 +38,10 @@ class ContainerRPMInclusionDepChainHandler(BaseKojiDepChainHandler):
 
     def _yield_koji_relationships_from_tag(self, pdc, tag):
 
-        release_id, release = pdcupdater.utils.tag2release(tag)
+        if self.pdc_tag_mapping:
+            release_id, release = pdcupdater.utils.tag2release(tag, pdc=pdc)
+        else:
+            release_id, release = pdcupdater.utils.tag2release(tag)
         # TODO -- this tag <-> release agreement is going to break down with modularity.
 
         pdcupdater.utils.ensure_release_exists(pdc, release_id, release)


### PR DESCRIPTION
In Fedora, when presented with a koji tag, our code who just do some string
coercion to figure out what release it was associated with.  We would guess.

The internal instance of PDC however has a field that lets you look up a
release given a tag.  This patch lets us use that field if configured, but
still retains the guesswork code for when PDC cannot provide that info.