### PR TITLE
Backend support for other busses.

### DIFF
--- a/pdcupdater/consumer.py
+++ b/pdcupdater/consumer.py
@@ -51,9 +51,15 @@ class PDCUpdater(fedmsg.consumers.FedmsgConsumer):
         super(PDCUpdater, self).__init__(hub)
 
     def consume(self, msg):
-        msg = msg['body']  # Remove envelope
+        # Remove the envelope
+        headers = msg.get('headers', {})  # https://github.com/mokshaproject/moksha/pull/35
+        topic, msg = msg['topic'], msg['body']
+
+        # Stuff topic and headers back into the message body, for convenience.
+        msg['topic'] = topic
+        msg['headers'] = headers
+
         idx = msg.get('msg_id', None)
-        topic = msg.get('topic', None)
         self.log.debug("Received %r, %r" % (idx, topic))
 
         pdc = pdc_client.PDCClient(**self.pdc_config)

--- a/pdcupdater/consumer.py
+++ b/pdcupdater/consumer.py
@@ -50,10 +50,10 @@ class PDCUpdater(fedmsg.consumers.FedmsgConsumer):
 
         super(PDCUpdater, self).__init__(hub)
 
-    def consume(self, msg):
+    def consume(self, envelope):
         # Remove the envelope
-        headers = msg.get('headers', {})  # https://github.com/mokshaproject/moksha/pull/35
-        topic, msg = msg['topic'], msg['body']
+        headers = envelope.get('headers', {})  # https://github.com/mokshaproject/moksha/pull/35
+        topic, msg = envelope['topic'], envelope['body']
 
         # Stuff topic and headers back into the message body, for convenience.
         msg['topic'] = topic

--- a/pdcupdater/tests/handler_tests/__init__.py
+++ b/pdcupdater/tests/handler_tests/__init__.py
@@ -64,6 +64,7 @@ def mock_pdc(function):
         pdc.add_endpoint('releases/fedora-20-updates', 'GET', {})
         pdc.add_endpoint('releases/epel-7-updates', 'GET', {})
         pdc.add_endpoint('releases/epel-6-updates', 'GET', {})
+        pdc.add_endpoint('releases/rhel-9000', 'GET', {})
 
 
         pdc.add_endpoint('component-groups', 'GET', {

--- a/pdcupdater/tests/handler_tests/data/messagebus-example1.json
+++ b/pdcupdater/tests/handler_tests/data/messagebus-example1.json
@@ -1,0 +1,58 @@
+{
+  "body": {
+    "tag": {
+      "maven_support": false, 
+      "arches": null, 
+      "locked": false, 
+      "name": "rhel-9000-candidate", 
+      "extra": {}, 
+      "maven_include_all": false, 
+      "id": 9895, 
+      "perm": null, 
+      "perm_id": null
+    }, 
+    "force": false, 
+    "build": {
+      "package_name": "rhel-release", 
+      "extra": null, 
+      "creation_time": "2016-12-12 16:03:37.724045", 
+      "completion_time": "2016-12-12 16:06:00.612419", 
+      "package_id": 19646, 
+      "id": 528225, 
+      "build_id": 528225, 
+      "state": 1, 
+      "source": null, 
+      "epoch": null, 
+      "version": "9000", 
+      "completion_ts": 1481558760.61242, 
+      "owner_id": 1251, 
+      "owner_name": "somebody", 
+      "nvr": "rhel-release-9000-0.el9000", 
+      "start_time": "2016-12-12 16:03:37.724045", 
+      "creation_event_id": 14538656, 
+      "start_ts": 1481558617.72405, 
+      "volume_id": 0, 
+      "creation_ts": 1481558617.72405, 
+      "name": "rhel-release", 
+      "task_id": 12224893, 
+      "volume_name": "DEFAULT", 
+      "release": "0.el9000"
+    }, 
+    "user": {
+      "status": 0, 
+      "krb_principal": "somebody@REDHAT.COM", 
+      "usertype": 0, 
+      "id": 1251, 
+      "name": "somebody"
+    }
+  }, 
+  "headers": {
+    "name": "rhel-release", 
+    "tag": "rhel-9000-candidate", 
+    "user": "somebody", 
+    "version": "9000", 
+    "release": "0.el9000", 
+    "type": "Tag"
+  },
+  "topic": "brew.exchange"
+}

--- a/pdcupdater/tests/handler_tests/test_depchain_rpms.py
+++ b/pdcupdater/tests/handler_tests/test_depchain_rpms.py
@@ -4,6 +4,7 @@ import os
 import mock
 
 import pdcupdater.utils
+import pdcupdater.handlers.depchain.rpms
 from pdcupdater.tests.handler_tests import (
     BaseHandlerTest, mock_pdc
 )
@@ -152,7 +153,7 @@ class TestBuildtimeDepIngestion(BaseHandlerTest):
         ]))
 
 
-class TestRuntimeDepIngestion(BaseHandlerTest):
+class TestRuntimeDepIngestionFedora(BaseHandlerTest):
     handler_path = 'pdcupdater.handlers.depchain.rpms:NewRPMRunTimeDepChainHandler'
     config = {}
 
@@ -268,6 +269,17 @@ class TestRuntimeDepIngestion(BaseHandlerTest):
 
         self.assertDictEqual(pdc.calls, expected_calls)
 
+
+class FakeHandler(pdcupdater.handlers.depchain.rpms.BaseRPMDepChainHandler):
+    # TODO -- working here.  make a fake handler so we can avoid trying to make
+    # calls to koji about rpms in RHEL 9000, which doesn't exist.
+    pass
+
+
+class TestRuntimeDepIngestionRedHat(BaseHandlerTest):
+    handler_path = 'pdcupdater.tests.handler_tests.test_depchain_rpms:FakeHandler'
+    config = {}
+
     @mock.patch('pdcupdater.utils.interesting_tags')
     def test_handle_brew_message(self, tags):
         tags.return_value = ['rhel-9000-candidate']
@@ -277,9 +289,12 @@ class TestRuntimeDepIngestion(BaseHandlerTest):
 
     @mock_pdc
     @mock.patch('pdcupdater.services.koji_list_buildroot_for')
+    @mock.patch('pdcupdater.utils.tag2release')
     @mock.patch('pdcupdater.utils.interesting_tags')
-    def test_handle_new_brew_build(self, pdc, tags, buildroot):
+    def test_handle_new_brew_build(self, pdc, tags, tag2release, buildroot):
         tags.return_value = ['rhel-9000-candidate']
+        tag2release.return_value = 'rhel-9000', {
+        }
         buildroot.return_value = [
             {'name': 'wat', 'is_update': True},
         ]


### PR DESCRIPTION
Koji upstream comes with a `messagebus` plugin that we don't use in Fedora.
This change updates our depchain handlers to be able to deal with the format of
messages for both fedmsg, and that messagebus plugin.