### PR TITLE
Change Brew Suffix

### DIFF
--- a/pdcupdater/handlers/depchain/base.py
+++ b/pdcupdater/handlers/depchain/base.py
@@ -48,7 +48,7 @@ class BaseKojiDepChainHandler(pdcupdater.handlers.BaseHandler):
             # Fedora messaging
             'buildsys.tag',
             # Red Hat.
-            'brew.exchange',
+            'brew.build.tag',
         ]
 
     @classmethod

--- a/pdcupdater/tests/handler_tests/data/messagebus-example1.json
+++ b/pdcupdater/tests/handler_tests/data/messagebus-example1.json
@@ -54,5 +54,5 @@
     "release": "0.el9000", 
     "type": "Tag"
   },
-  "topic": "brew.exchange"
+  "topic": "VirtualTopic.eng.brew.build.tag"
 }


### PR DESCRIPTION
When ingesting internal messages, the topic I've been using is `/queue/Consumer.pdc-updater-prod.VirtualTopic.eng.brew.build.tag`, so `brew.exchange` needs to be changed to `brew.build.tag`.