### PR TITLE
Parses message-id from internal messages

### DIFF
--- a/pdcupdater/consumer.py
+++ b/pdcupdater/consumer.py
@@ -59,8 +59,11 @@ class PDCUpdater(fedmsg.consumers.FedmsgConsumer):
         msg['topic'] = topic
         msg['headers'] = headers
 
-        idx = msg.get('msg_id', None)
-        self.log.debug("Received %r, %r" % (idx, topic))
+        # If the message is internal, the message id is in the headers
+        if 'message-id' in msg['headers']:
+            msg['msg_id'] = msg['headers']['message-id']
+
+        self.log.debug("Received %r, %r" % (msg['msg_id'], topic))
 
         pdc = pdc_client.PDCClient(**self.pdc_config)
         pdcupdater.utils.handle_message(pdc, self.handlers, msg)

--- a/pdcupdater/tests/handler_tests/data/messagebus-example1.json
+++ b/pdcupdater/tests/handler_tests/data/messagebus-example1.json
@@ -47,6 +47,7 @@
     }
   }, 
   "headers": {
+    "message-id": "ID\\cmessage.example.local-51829-1480694134970-4\\c312989\\c0\\c0\\c1",
     "name": "rhel-release", 
     "tag": "rhel-9000-candidate", 
     "user": "somebody", 
@@ -54,5 +55,6 @@
     "release": "0.el9000", 
     "type": "Tag"
   },
+  "msg-id": "ID\\cmessage.example.local-51829-1480694134970-4\\c312989\\c0\\c0\\c1",
   "topic": "VirtualTopic.eng.brew.build.tag"
 }


### PR DESCRIPTION
This attempts to solve the following error:
```
Jan 05 15:57:28 mprahl-pdc-updater-test.localdomain fedmsg-hub[18908]: Traceback (most recent call last):
Jan 05 15:57:28 mprahl-pdc-updater-test.localdomain fedmsg-hub[18908]: File "/usr/lib/python2.7/site-packages/moksha/hub/api/consumer.py", line 191, in _work
Jan 05 15:57:28 mprahl-pdc-updater-test.localdomain fedmsg-hub[18908]: self.consume(message)
Jan 05 15:57:28 mprahl-pdc-updater-test.localdomain fedmsg-hub[18908]: File "/usr/lib/python2.7/site-packages/pdcupdater/consumer.py", line 66, in consume
Jan 05 15:57:28 mprahl-pdc-updater-test.localdomain fedmsg-hub[18908]: pdcupdater.utils.handle_message(pdc, self.handlers, msg)
Jan 05 15:57:28 mprahl-pdc-updater-test.localdomain fedmsg-hub[18908]: File "/usr/lib/python2.7/site-packages/pdcupdater/utils.py", line 439, in handle_message
Jan 05 15:57:28 mprahl-pdc-updater-test.localdomain fedmsg-hub[18908]: idx, topic = msg['msg_id'], msg['topic']
Jan 05 15:57:28 mprahl-pdc-updater-test.localdomain fedmsg-hub[18908]: KeyError: 'msg_id'
```