### PR TITLE
Gather interesting_tags from PDC if pdc_tag_mapping is True.

### DIFF
--- a/fedmsg.d/pdcupdater-example.py
+++ b/fedmsg.d/pdcupdater-example.py
@@ -55,6 +55,11 @@ config = {
         'pdcupdater.handlers.depchain.containers:ContainerRPMInclusionDepChainHandler',
     ],
 
+    # Configure tags of interest for various depchain handlers here
+    'pdcupdater.ContainerRPMInclusionDepChainHandler.interesting_tags': [
+        'f24-docker',
+    ],
+
     # Augment the base fedmsg logging config to also handle pdcupdater loggers.
     'logging': dict(
         loggers=dict(

--- a/pdcupdater/handlers/__init__.py
+++ b/pdcupdater/handlers/__init__.py
@@ -29,7 +29,7 @@ class BaseHandler(object):
         pass
 
     @abc.abstractmethod
-    def can_handle(self, msg):
+    def can_handle(self, pdc, msg):
         """ Return True or False if this handler can handle this message. """
         pass
 

--- a/pdcupdater/handlers/atomic.py
+++ b/pdcupdater/handlers/atomic.py
@@ -27,7 +27,7 @@ class AtomicComponentGroupHandler(pdcupdater.handlers.BaseHandler):
             'trac.git.receive',
         ]
 
-    def can_handle(self, msg):
+    def can_handle(self, pdc, msg):
         if not msg['topic'].endswith('trac.git.receive'):
             return False
         if msg['msg']['commit']['repo'] != 'fedora-atomic':

--- a/pdcupdater/handlers/compose.py
+++ b/pdcupdater/handlers/compose.py
@@ -33,7 +33,7 @@ class NewComposeHandler(pdcupdater.handlers.BaseHandler):
             'pungi.compose.status.change',
         ]
 
-    def can_handle(self, msg):
+    def can_handle(self, pdc, msg):
         if not msg['topic'].endswith('pungi.compose.status.change'):
             return False
         if not msg['msg']['status'] in final:

--- a/pdcupdater/handlers/depchain/base.py
+++ b/pdcupdater/handlers/depchain/base.py
@@ -39,7 +39,7 @@ class BaseKojiDepChainHandler(pdcupdater.handlers.BaseHandler):
     def _yield_koji_relationships_from_tag(self, koji_url, tag):
         raise NotImplementedError("Subclasses must implement this.")
 
-    def interesting_tags(self):
+    def interesting_tags(self, pdc):
         raise NotImplementedError("Subclasses must implement this.")
 
     def __init__(self, *args, **kwargs):
@@ -78,7 +78,7 @@ class BaseKojiDepChainHandler(pdcupdater.handlers.BaseHandler):
         else:
             return msg['body']['build']['build_id']
 
-    def can_handle(self, msg):
+    def can_handle(self, pdc, msg):
         if not any([msg['topic'].endswith(suffix)
                     for suffix in self.topic_suffixes]):
             return False
@@ -89,7 +89,7 @@ class BaseKojiDepChainHandler(pdcupdater.handlers.BaseHandler):
             log.debug("From %r.  Skipping." % instance)
             return False
 
-        interesting = self.interesting_tags()
+        interesting = self.interesting_tags(pdc)
         tag = self.extract_tag(msg)
 
         if tag not in interesting:
@@ -176,7 +176,7 @@ class BaseKojiDepChainHandler(pdcupdater.handlers.BaseHandler):
 
     def audit(self, pdc):
         present, absent = set(), set()
-        tags = self.interesting_tags()
+        tags = self.interesting_tags(pdc)
 
         for tag in tags:
             log.info("Starting audit of tag %r of %r." % (tag, tags))
@@ -206,7 +206,7 @@ class BaseKojiDepChainHandler(pdcupdater.handlers.BaseHandler):
         return present, absent
 
     def initialize(self, pdc):
-        tags = self.interesting_tags()
+        tags = self.interesting_tags(pdc)
         tags.reverse()
 
         for tag in tags:

--- a/pdcupdater/handlers/depchain/containers.py
+++ b/pdcupdater/handlers/depchain/containers.py
@@ -34,10 +34,16 @@ class ContainerRPMInclusionDepChainHandler(BaseKojiDepChainHandler):
     child_type = 'rpm'
 
     def interesting_tags(self):
-        return pdcupdater.utils.interesting_container_tags()
+        key = "pdcupdater.%s.interesting_tags" % str(type(self))
+
+        if not self.config.get(key):
+            log.debug("config key %s has no value.  performing queries." % key)
+            return pdcupdater.utils.interesting_container_tags()
+
+        log.debug("using value from config key %s" % key)
+        return self.config[key]
 
     def _yield_koji_relationships_from_tag(self, pdc, tag):
-
         if self.pdc_tag_mapping:
             release_id, release = pdcupdater.utils.tag2release(tag, pdc=pdc)
         else:

--- a/pdcupdater/handlers/depchain/containers.py
+++ b/pdcupdater/handlers/depchain/containers.py
@@ -33,7 +33,7 @@ class ContainerRPMInclusionDepChainHandler(BaseKojiDepChainHandler):
     parent_type = 'container'
     child_type = 'rpm'
 
-    def interesting_tags(self):
+    def interesting_tags(self, pdc):
         key = "pdcupdater.%s.interesting_tags" % str(type(self))
 
         if not self.config.get(key):

--- a/pdcupdater/handlers/depchain/rpms.py
+++ b/pdcupdater/handlers/depchain/rpms.py
@@ -83,12 +83,15 @@ class NewRPMBuildTimeDepChainHandler(BaseRPMDepChainHandler):
     parent_type = 'rpm'
     child_type = 'rpm'
 
-    def interesting_tags(self):
+    def interesting_tags(self, pdc):
         key = "pdcupdater.%s.interesting_tags" % str(type(self))
 
         if not self.config.get(key):
             log.debug("config key %s has no value.  performing queries." % key)
-            return pdcupdater.utils.interesting_tags()
+            if self.pdc_tag_mapping:
+                return pdcupdater.utils.all_tags_from_pdc(pdc)
+            else:
+                return pdcupdater.utils.interesting_tags()
 
         log.debug("using value from config key %s" % key)
         return self.config[key]
@@ -140,12 +143,15 @@ class NewRPMRunTimeDepChainHandler(BaseRPMDepChainHandler):
     parent_type = 'rpm'
     child_type = 'rpm'
 
-    def interesting_tags(self):
+    def interesting_tags(self, pdc):
         key = "pdcupdater.%s.interesting_tags" % str(type(self))
 
         if not self.config.get(key):
             log.debug("config key %s has no value.  performing queries." % key)
-            return pdcupdater.utils.interesting_tags()
+            if self.pdc_tag_mapping:
+                return pdcupdater.utils.all_tags_from_pdc(pdc)
+            else:
+                return pdcupdater.utils.interesting_tags()
 
         log.debug("using value from config key %s" % key)
         return self.config[key]

--- a/pdcupdater/handlers/depchain/rpms.py
+++ b/pdcupdater/handlers/depchain/rpms.py
@@ -84,7 +84,14 @@ class NewRPMBuildTimeDepChainHandler(BaseRPMDepChainHandler):
     child_type = 'rpm'
 
     def interesting_tags(self):
-        return pdcupdater.utils.interesting_tags()
+        key = "pdcupdater.%s.interesting_tags" % str(type(self))
+
+        if not self.config.get(key):
+            log.debug("config key %s has no value.  performing queries." % key)
+            return pdcupdater.utils.interesting_tags()
+
+        log.debug("using value from config key %s" % key)
+        return self.config[key]
 
     def _yield_koji_relationships_from_build(self, koji_url, build_id, rpms=None):
 
@@ -134,7 +141,14 @@ class NewRPMRunTimeDepChainHandler(BaseRPMDepChainHandler):
     child_type = 'rpm'
 
     def interesting_tags(self):
-        return pdcupdater.utils.interesting_tags()
+        key = "pdcupdater.%s.interesting_tags" % str(type(self))
+
+        if not self.config.get(key):
+            log.debug("config key %s has no value.  performing queries." % key)
+            return pdcupdater.utils.interesting_tags()
+
+        log.debug("using value from config key %s" % key)
+        return self.config[key]
 
     def _yield_koji_relationships_from_build(self, koji_url, build_id, rpms=None):
 

--- a/pdcupdater/handlers/persons.py
+++ b/pdcupdater/handlers/persons.py
@@ -13,7 +13,7 @@ class NewPersonHandler(pdcupdater.handlers.BaseHandler):
     def topic_suffixes(self):
         return ['fas.user.create']
 
-    def can_handle(self, msg):
+    def can_handle(self, pdc, msg):
         return msg['topic'].endswith('fas.user.create')
 
     def handle(self, pdc, msg):

--- a/pdcupdater/handlers/pkgdb.py
+++ b/pdcupdater/handlers/pkgdb.py
@@ -42,7 +42,7 @@ class NewPackageHandler(pdcupdater.handlers.BaseHandler):
     def topic_suffixes(self):
         return ['pkgdb.package.new']
 
-    def can_handle(self, msg):
+    def can_handle(self, pdc, msg):
         return msg['topic'].endswith('pkgdb.package.new')
 
     def handle(self, pdc, msg):
@@ -103,7 +103,7 @@ class NewPackageBranchHandler(pdcupdater.handlers.BaseHandler):
     def topic_suffixes(self):
         return ['pkgdb.package.branch.new']
 
-    def can_handle(self, msg):
+    def can_handle(self, pdc, msg):
         return msg['topic'].endswith('pkgdb.package.branch.new')
 
     def handle(self, pdc, msg):

--- a/pdcupdater/handlers/rpms.py
+++ b/pdcupdater/handlers/rpms.py
@@ -24,7 +24,7 @@ class NewRPMHandler(pdcupdater.handlers.BaseHandler):
     def topic_suffixes(self):
         return ['buildsys.tag']
 
-    def can_handle(self, msg):
+    def can_handle(self, pdc, msg):
         if not msg['topic'].endswith('buildsys.tag'):
             return False
 

--- a/pdcupdater/tests/handler_tests/test_atomic.py
+++ b/pdcupdater/tests/handler_tests/test_atomic.py
@@ -15,7 +15,7 @@ class TestAtomicUpdate(BaseHandlerTest):
     def test_cannot_handle_other_git_push(self):
         idx = '2016-ab90226c-5fc3-48f8-83de-821e4fe0ade4'
         msg = pdcupdater.utils.get_fedmsg(idx)
-        result = self.handler.can_handle(msg)
+        result = self.handler.can_handle(None, msg)
         self.assertEquals(result, False)
 
     def test_can_handle_atomic_update_push(self):
@@ -28,7 +28,7 @@ class TestAtomicUpdate(BaseHandlerTest):
                 },
             },
         }
-        result = self.handler.can_handle(msg)
+        result = self.handler.can_handle(None, msg)
         self.assertEquals(result, True)
 
     @mock_pdc

--- a/pdcupdater/tests/handler_tests/test_compose.py
+++ b/pdcupdater/tests/handler_tests/test_compose.py
@@ -31,7 +31,7 @@ class TestNewCompose(BaseHandlerTest):
     def test_cannot_handle_fedbadges(self):
         idx = '2015-6c98c8e3-0dcb-497d-a0d8-0b3d026a4cfb'
         msg = pdcupdater.utils.get_fedmsg(idx)
-        result = self.handler.can_handle(msg)
+        result = self.handler.can_handle(None, msg)
         self.assertEquals(result, False)
 
     def test_cannot_handle_new_compose_start(self):
@@ -47,7 +47,7 @@ class TestNewCompose(BaseHandlerTest):
                 'Fedora-24-20151130.n.2/compose',
             ),
         )
-        result = self.handler.can_handle(msg)
+        result = self.handler.can_handle(None, msg)
         self.assertEquals(result, False)
 
     def test_cannot_handle_new_compose_doomed(self):
@@ -63,7 +63,7 @@ class TestNewCompose(BaseHandlerTest):
                 'Fedora-24-20151130.n.2/compose',
             ),
         )
-        result = self.handler.can_handle(msg)
+        result = self.handler.can_handle(None, msg)
         self.assertEquals(result, False)
 
     def test_can_handle_new_compose_finish(self):
@@ -79,7 +79,7 @@ class TestNewCompose(BaseHandlerTest):
                 'Fedora-24-20151130.n.2/compose',
             ),
         )
-        result = self.handler.can_handle(msg)
+        result = self.handler.can_handle(None, msg)
         self.assertEquals(result, True)
 
     @mock_pdc

--- a/pdcupdater/tests/handler_tests/test_depchain_containers.py
+++ b/pdcupdater/tests/handler_tests/test_depchain_containers.py
@@ -18,7 +18,7 @@ class TestInclusionDepIngestion(BaseHandlerTest):
         rawhide.return_value = 'f24'
         idx = '2016-b78e670b-e8f7-4987-868e-1260cc0f3fbd'
         msg = pdcupdater.utils.get_fedmsg(idx)
-        result = self.handler.can_handle(msg)
+        result = self.handler.can_handle(None, msg)
         self.assertEquals(result, True)
 
     @mock_pdc

--- a/pdcupdater/tests/handler_tests/test_depchain_rpms.py
+++ b/pdcupdater/tests/handler_tests/test_depchain_rpms.py
@@ -26,7 +26,7 @@ class TestBuildtimeDepIngestion(BaseHandlerTest):
         rawhide.return_value = 'f24'
         idx = '2016-662e75d1-5830-4c84-9855-fd07a3018f7a'
         msg = pdcupdater.utils.get_fedmsg(idx)
-        result = self.handler.can_handle(msg)
+        result = self.handler.can_handle(None, msg)
         self.assertEquals(result, True)
 
     def test_construct_topic_fedora_message(self):
@@ -289,7 +289,7 @@ class FakeHandler(pdcupdater.handlers.depchain.rpms.BaseRPMDepChainHandler):
     parent_type = 'rpm'
     child_type = 'rpm'
 
-    def interesting_tags(self):
+    def interesting_tags(self, pdc):
         return ['rhel-9000-candidate']
 
     def _yield_koji_relationships_from_build(self, url, build, rpms=None):
@@ -302,7 +302,7 @@ class TestRuntimeDepIngestionRedHat(BaseHandlerTest):
 
     def test_handle_brew_message(self):
         msg = load_example_message('messagebus-example1.json')
-        result = self.handler.can_handle(msg)
+        result = self.handler.can_handle(None, msg)
         self.assertEquals(result, True)
 
     def test_construct_topic_brew_message(self):

--- a/pdcupdater/tests/handler_tests/test_persons.py
+++ b/pdcupdater/tests/handler_tests/test_persons.py
@@ -13,13 +13,13 @@ class TestNewPerson(BaseHandlerTest):
     def test_cannot_handle_fedbadges(self):
         idx = '2015-6c98c8e3-0dcb-497d-a0d8-0b3d026a4cfb'
         msg = pdcupdater.utils.get_fedmsg(idx)
-        result = self.handler.can_handle(msg)
+        result = self.handler.can_handle(None, msg)
         self.assertEquals(result, False)
 
     def test_can_handle_fas_new_person(self):
         idx = '2015-b456fe4e-6dff-431a-9116-280064fe6087'
         msg = pdcupdater.utils.get_fedmsg(idx)
-        result = self.handler.can_handle(msg)
+        result = self.handler.can_handle(None, msg)
         self.assertEquals(result, True)
 
     @mock_pdc

--- a/pdcupdater/tests/handler_tests/test_pkgdb.py
+++ b/pdcupdater/tests/handler_tests/test_pkgdb.py
@@ -265,25 +265,25 @@ class TestNewPackage(BaseHandlerTest):
     def test_cannot_handle_fedbadges(self):
         idx = '2015-6c98c8e3-0dcb-497d-a0d8-0b3d026a4cfb'
         msg = pdcupdater.utils.get_fedmsg(idx)
-        result = self.handler.can_handle(msg)
+        result = self.handler.can_handle(None, msg)
         self.assertEquals(result, False)
 
     def test_cannot_handle_bodhi(self):
         idx = '2015-9045593c-7376-43e8-af15-dc4c3fadc1f5'
         msg = pdcupdater.utils.get_fedmsg(idx)
-        result = self.handler.can_handle(msg)
+        result = self.handler.can_handle(None, msg)
         self.assertEquals(result, False)
 
     def test_cannot_handle_pkgdb_new_branch(self):
         idx = '2015-fc7a1d4f-56d8-45d6-a780-b317f0033a16'
         msg = pdcupdater.utils.get_fedmsg(idx)
-        result = self.handler.can_handle(msg)
+        result = self.handler.can_handle(None, msg)
         self.assertEquals(result, False)
 
     def test_can_handle_pkgdb_new_package(self):
         idx = '2015-5affaacc-1539-4e4f-9a5c-5b3f5c7caccf'
         msg = pdcupdater.utils.get_fedmsg(idx)
-        result = self.handler.can_handle(msg)
+        result = self.handler.can_handle(None, msg)
         self.assertEquals(result, True)
 
     @mock_pdc
@@ -439,13 +439,13 @@ class TestNewBranch(BaseHandlerTest):
     def test_can_handle_pkgdb_new_branch(self):
         idx = '2015-fc7a1d4f-56d8-45d6-a780-b317f0033a16'
         msg = pdcupdater.utils.get_fedmsg(idx)
-        result = self.handler.can_handle(msg)
+        result = self.handler.can_handle(None, msg)
         self.assertEquals(result, True)
 
     def test_cannot_handle_pkgdb_new_package(self):
         idx = '2015-5affaacc-1539-4e4f-9a5c-5b3f5c7caccf'
         msg = pdcupdater.utils.get_fedmsg(idx)
-        result = self.handler.can_handle(msg)
+        result = self.handler.can_handle(None, msg)
         self.assertEquals(result, False)
 
     @mock_pdc

--- a/pdcupdater/tests/handler_tests/test_rpms.py
+++ b/pdcupdater/tests/handler_tests/test_rpms.py
@@ -104,31 +104,31 @@ class TestNewRPM(BaseHandlerTest):
     def test_cannot_handle_fedbadges(self):
         idx = '2015-6c98c8e3-0dcb-497d-a0d8-0b3d026a4cfb'
         msg = pdcupdater.utils.get_fedmsg(idx)
-        result = self.handler.can_handle(msg)
+        result = self.handler.can_handle(None, msg)
         self.assertEquals(result, False)
 
     def test_cannot_handle_non_stable_or_rawhide_build(self):
         idx = '2015-bf628d37-11bf-4354-a628-b3abfea03ed7'
         msg = pdcupdater.utils.get_fedmsg(idx)
-        result = self.handler.can_handle(msg)
+        result = self.handler.can_handle(None, msg)
         self.assertEquals(result, False)
 
     def test_cannot_handle_non_primary_rawhide_build(self):
         idx = '2015-e398ba94-827a-4c97-ac4b-39e5a6028818'
         msg = pdcupdater.utils.get_fedmsg(idx)
-        result = self.handler.can_handle(msg)
+        result = self.handler.can_handle(None, msg)
         self.assertEquals(result, False)
 
     def test_can_handle_new_primary_rawhide_build(self):
         idx = '2015-c37d4607-e8de-4229-990a-981c40a9bb93'
         msg = pdcupdater.utils.get_fedmsg(idx)
-        result = self.handler.can_handle(msg)
+        result = self.handler.can_handle(None, msg)
         self.assertEquals(result, True)
 
     def test_can_handle_stable_update_tag(self):
         idx = '2015-19772dd8-21f4-4b25-a557-41d313a74a88'
         msg = pdcupdater.utils.get_fedmsg(idx)
-        result = self.handler.can_handle(msg)
+        result = self.handler.can_handle(None, msg)
         self.assertEquals(result, True)
 
     @mock_pdc

--- a/pdcupdater/utils.py
+++ b/pdcupdater/utils.py
@@ -498,9 +498,7 @@ def interesting_container_tags():
 
 
 def all_tags_from_pdc(pdc):
-    for release in pdc.get_paged(pdc['releases']._):
-        if not release['active']:
-            continue
+    for release in pdc.get_paged(pdc['releases']._, active=True):
         brew_data = release.get('brew') or {}
         for tag in brew_data.get('allowed_tags', []):
             yield tag

--- a/pdcupdater/utils.py
+++ b/pdcupdater/utils.py
@@ -439,7 +439,7 @@ def handle_message(pdc, handlers, msg, verbose=False):
     idx, topic = msg['msg_id'], msg['topic']
     for handler in handlers:
         name = type(handler).__name__
-        if not handler.can_handle(msg):
+        if not handler.can_handle(pdc, msg):
             if verbose:
                 log.info("%s could not handle %s" % (name, idx))
             continue
@@ -495,6 +495,15 @@ def interesting_container_tags():
     #tags = interesting_tags()
     #tags = [tag for tag in tags if '-' not in tag]
     #return ['%s-docker' % tag for tag in tags]
+
+
+def all_tags_from_pdc(pdc):
+    for release in pdc.get_paged(pdc['releases']._):
+        if not release['active']:
+            continue
+        brew_data = release.get('brew') or {}
+        for tag in brew_data.get('allowed_tags', []):
+            yield tag
 
 
 def release2reponame(release):


### PR DESCRIPTION
Also, allow configuring which tags different depchain handlers should look for.

This is necessary, because I don't see a way to dynamically fetch the set of tags that docker containers are constructed from.