### PR TITLE
A second stab at getting the release type right from composes.

### DIFF
--- a/pdcupdater/handlers/compose.py
+++ b/pdcupdater/handlers/compose.py
@@ -135,7 +135,7 @@ class NewComposeHandler(pdcupdater.handlers.BaseHandler):
         composeinfo['payload']['release']['short'] = \
             composeinfo['payload']['release']['short'].lower()
         release = copy.copy(composeinfo['payload']['release'])
-        release['release_type'] = 'ga'
+        release['release_type'] = release.pop('type')
         release_id = "{short}-{version}".format(**release)
         pdcupdater.utils.ensure_release_exists(pdc, release_id, release)
 


### PR DESCRIPTION
This supersedes #38, which was the wrong approach.