### PR TITLE
Fix traceback occurring when `taskid` is `None`

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,8 +21,7 @@ $script = <<SCRIPT
 SCRIPT
 
 Vagrant.configure("2") do |config|
-  # config.vm.box = "fedora/24-cloud-base"
-  config.vm.box = "boxcutter/fedora24"
+  config.vm.box = "fedora/24-cloud-base"
   config.vm.provider :virtualbox do |v|
     v.customize ["modifyvm", :id, "--memory", 2048]
   end

--- a/fedmsg.d/pdcupdater-example.py
+++ b/fedmsg.d/pdcupdater-example.py
@@ -30,7 +30,7 @@ config = {
     'pdcupdater.pkgdb_url': 'https://admin.fedoraproject.org/pkgdb',
 
     # Koji details
-    'pdcupdater.koji_url': 'http://koji.fedoraproject.org/kojihub',
+    'pdcupdater.koji_url': 'https://koji.fedoraproject.org/kojihub',
     # Use 8 threads to talk to koji in parallel.
     'pdcupdater.koji_io_threads': 8,
 

--- a/pdcupdater/services.py
+++ b/pdcupdater/services.py
@@ -202,19 +202,10 @@ def koji_rpms_from_build(url, build_id):
     log.info("Listing rpms in koji(%s) for %r" % (url, build_id))
     session = koji.ClientSession(url)
     build = koji_get_build(url, build_id)
-    children = session.getTaskChildren(build['task_id'])
 
     rpms = set()
-    for child in children:
-        results = session.getTaskResult(child['id'])
-        if not results:
-            continue
-
-        # rpm looks like 'tasks/4547/12094547/podofo-0.9.1-17.el7.ppc64.rpm'
-        for rpm in results.get('rpms', []):
-            rpms.add(rpm.split('/')[-1])
-        for rpm in results.get('srpms', []):
-            rpms.add(rpm.split('/')[-1])
+    for rpm in session.listRPMs(buildID=build_id):
+        rpms.add('{0}.{1}.rpm'.format(rpm['nvr'], rpm['arch']))
 
     # Dependable order for testing.
     rpms = list(sorted(rpms))

--- a/pdcupdater/tests/handler_tests/__init__.py
+++ b/pdcupdater/tests/handler_tests/__init__.py
@@ -323,7 +323,7 @@ class BaseHandlerTest(unittest.TestCase):
             'password': 'whatever',
         },
         'pdcupdater.pkgdb_url': 'blihblihblih',
-        'pdcupdater.koji_url': 'http://koji.fedoraproject.org/kojihub',
+        'pdcupdater.koji_url': 'https://koji.fedoraproject.org/kojihub',
         'pdcupdater.old_composes_url': 'https://kojipkgs.fedoraproject.org/compose',
         'pdcupdater.fedora_atomic_git_url': 'https://pagure.io/fedora-atomic/raw/master/f/',
     }

--- a/pdcupdater/tests/handler_tests/test_depchain_rpms.py
+++ b/pdcupdater/tests/handler_tests/test_depchain_rpms.py
@@ -78,9 +78,9 @@ class TestBuildtimeDepIngestion(BaseHandlerTest):
         ]
         self.assertEquals(pdc.calls.keys(), expected_keys)
 
-        self.assertEqual(len(pdc.calls['global-components']), 21)
-        self.assertEqual(len(pdc.calls['release-components']), 21)
-        self.assertEqual(len(pdc.calls['release-component-relationships']), 63)
+        self.assertEqual(len(pdc.calls['global-components']), 22)
+        self.assertEqual(len(pdc.calls['release-components']), 22)
+        self.assertEqual(len(pdc.calls['release-component-relationships']), 66)
 
     @mock_pdc
     @mock.patch('pdcupdater.utils.rawhide_tag')


### PR DESCRIPTION
Originally we were getting the list of RPM's for a build by querying for the build and then querying for the task that built the RPM. In builds where the RPM's are built outside of Koji (i.e. OSBS) and are later imported, then there are no tasks associated with the build to get the RPM's using this method. This is replaced with a `listRPMs` API function call which simplifies this and seems to resolve this issue.

Additionally, this changes the default Koji Hub URL to use HTTPS because it seems to be required.

My concern is that if there are no RPM's associated with the build, an empty list is returned. Will the code that call this handle it gracefully? A quick glance seems to indicate that it'd be okay, but without being super familiar with the code base I'd like a second opinion on this.