### PR TITLE
Gracefully fail if koji tag doesn't exist.

### DIFF
--- a/pdcupdater/services.py
+++ b/pdcupdater/services.py
@@ -159,7 +159,13 @@ def koji_rpms_in_tag(url, tag):
     import koji
     log.info("Listing rpms in koji(%s) tag %s" % (url, tag))
     session = koji.ClientSession(url)
-    rpms, builds = session.listTaggedRPMS(tag, latest=True)
+
+    try:
+        rpms, builds = session.listTaggedRPMS(tag, latest=True)
+    except koji.GenericError as e:
+        log.exception("Failed to list rpms in tag %r" % tag)
+        # If the tag doesn't exist.. then there are no rpms in that tag.
+        return []
 
     # Extract some srpm-level info from the build attach it to each rpm
     builds = {build['build_id']: build for build in builds}


### PR DESCRIPTION
@mprahl found this in our audit log.  If PDC thinks a tag exist, but it doesn't
exist in Koji, then we should return an empty list of rpms -- there are no rpms
in that tag.. because the tag doesn't exist.

We also complain loudly with ``log.exception`` to make sure someone notices the
discrepancy.