### PR TITLE
Remove new internal field.

### DIFF
--- a/pdcupdater/handlers/compose.py
+++ b/pdcupdater/handlers/compose.py
@@ -136,6 +136,11 @@ class NewComposeHandler(pdcupdater.handlers.BaseHandler):
             composeinfo['payload']['release']['short'].lower()
         release = copy.copy(composeinfo['payload']['release'])
         release['release_type'] = release.pop('type', 'ga')
+
+        # PDC doesn't know about this field which showed up recently in pungi
+        # productmd metadata here.
+        release.pop('internal')
+
         release_id = "{short}-{version}".format(**release)
         pdcupdater.utils.ensure_release_exists(pdc, release_id, release)
 


### PR DESCRIPTION
It recently showed up in pungi productmd metadata.  When pdc-updater tries to
pass it on to PDC, it chokes.