### PR TITLE
Toggle modules to active=True when they are done building.

### DIFF
--- a/pdcupdater/handlers/modules.py
+++ b/pdcupdater/handlers/modules.py
@@ -75,6 +75,12 @@ class ModuleStateChangeHandler(pdcupdater.handlers.BaseHandler):
 
         unreleased_variant = self.get_or_create_unreleased_variant(pdc, body)
 
+        if body['state_name'] == 'ready':
+            uid = unreleased_variant['variant_uid']
+            # This submits an HTTP PATCH.
+            # The '/' is necessary to avoid losing the body in a 301.
+            pdc['unreleasedvariants'][uid + '/'] += {'variant_uid': uid, 'active': True}
+
         # trees are only present when a module is done building, i.e. states
         # 'done' or 'ready'
         if 'topdir' in body:

--- a/pdcupdater/handlers/modules.py
+++ b/pdcupdater/handlers/modules.py
@@ -130,12 +130,10 @@ class ModuleStateChangeHandler(pdcupdater.handlers.BaseHandler):
         # version/release, but for now we just do the right mapping here...
         variant_version =  body['stream'] # This is supposed to be equal to version
         variant_release =  body['version'] # This is supposed to be equal to release
+        variant_uid = "%s-%s-%s" % (variant_id, variant_version, variant_release)
 
         try:
-            unreleased_variant = pdc['unreleasedvariants'][variant_id]._(
-                variant_version=variant_version,
-                variant_release=variant_release,
-            )
+            unreleased_variant = pdc['unreleasedvariants'][variant_uid]._()
         except beanbag.BeanBagException as e:
             if e.response.status_code != 404:
                 raise

--- a/pdcupdater/handlers/modules.py
+++ b/pdcupdater/handlers/modules.py
@@ -75,7 +75,7 @@ class ModuleStateChangeHandler(pdcupdater.handlers.BaseHandler):
 
         unreleased_variant = self.get_or_create_unreleased_variant(pdc, body)
 
-        if body['state_name'] == 'ready':
+        if body['state'] == 5:
             uid = unreleased_variant['variant_uid']
             # This submits an HTTP PATCH.
             # The '/' is necessary to avoid losing the body in a 301.


### PR DESCRIPTION
This is for https://pagure.io/fm-orchestrator/issue/407

Here we also switch to using the variant_uid to lookup individual modules in
PDC which is introduced in fedora-modularity/product-definition-center#11.