### PR TITLE
Use hash instead of variant_uid for koji_tag, otherwise we hit the 50…

### DIFF
--- a/pdcupdater/handlers/modules.py
+++ b/pdcupdater/handlers/modules.py
@@ -8,6 +8,7 @@ import pdcupdater.handlers
 import pdcupdater.services
 
 import modulemd
+import hashlib
 
 log = logging.getLogger(__name__)
 
@@ -102,7 +103,10 @@ class ModuleStateChangeHandler(pdcupdater.handlers.BaseHandler):
         release = body['version']
         variant_uid = "{n}-{v}-{r}".format(n=name, v=version, r=release)
         variant_id = name
-        koji_tag = "module-" + variant_uid.lower()
+
+        tag_str = '.'.join([name, version, str(release)])
+        tag_hash = hashlib.sha1(tag_str).hexdigest()[:16]
+        koji_tag = "module-" + tag_hash
 
         data = {
             'variant_id': variant_id,


### PR DESCRIPTION
… characters limit for koji_tag used by Koji.