### PR TITLE
Add a handler so that PDC branches are EOL'd when the branch is retired

### DIFF
--- a/pdcupdater/handlers/retirement.py
+++ b/pdcupdater/handlers/retirement.py
@@ -1,0 +1,64 @@
+import logging
+from datetime import datetime
+
+import pdcupdater.services
+
+log = logging.getLogger(__name__)
+
+
+class RetireComponentHandler(pdcupdater.handlers.BaseHandler):
+    """ When a component's branch is retired, EOL all it's branches """
+
+    @property
+    def topic_suffixes(self):
+        return ['git.receive']
+
+    def can_handle(self, pdc, msg):
+        if not msg['topic'].endswith('git.receive'):
+            return False
+
+        # If there is no dead.package in the commit, then it can be ignored
+        if 'dead.package' not in msg['msg']['commit']['stats']['files']:
+            return False
+
+        dead_package_commit = \
+            msg['msg']['commit']['stats']['files']['dead.package']
+        # Only handles the message if the dead.package was added, not deleted
+        return dead_package_commit['additions'] > 0 \
+            and dead_package_commit['deletions'] == 0
+
+    def handle(self, pdc, msg):
+        branch = msg['msg']['commit']['branch']
+        repo = msg['msg']['commit']['repo']
+        namespace = msg['msg']['commit']['namespace']
+        # The dist-git namespaces are plural but the types are singular in PDC
+        if namespace.endswith('s'):
+            component_type = namespace[:-1]
+        else:
+            component_type = namespace
+        # This query guarantees a unique component branch, so a count of 1 is
+        # expected
+        branch_query_rv = pdc['component-branches']._(
+            name=branch, type=component_type, global_component=repo)
+
+        if branch_query_rv['count'] != 1:
+            log.error('"{0}/{1}" was not found in PDC'.format(namespace, repo))
+            return
+
+        branch = branch_query_rv['results'][0]
+        # If the branch is already EOL in PDC, don't do anything
+        if branch['active'] is False:
+            return
+
+        today = datetime.utcnow().date()
+        for sla in branch['slas']:
+            sla_eol = datetime.strptime(sla['eol'], '%Y-%m-%d').date()
+            if sla_eol > today:
+                pdc['component-branch-slas'][sla['id']]._ \
+                    += {'eol': str(today)}
+
+    def audit(self, pdc):
+        pass
+
+    def initialize(self, pdc):
+        pass

--- a/pdcupdater/handlers/retirement.py
+++ b/pdcupdater/handlers/retirement.py
@@ -50,6 +50,11 @@ class RetireComponentHandler(pdcupdater.handlers.BaseHandler):
         if branch['active'] is False:
             return
 
+        self._retire_branch(pdc, branch)
+
+    @staticmethod
+    def _retire_branch(pdc, branch):
+        log.info("Retiring {type}/{global_component}#{name}".format(**branch))
         today = datetime.utcnow().date()
         for sla in branch['slas']:
             sla_eol = datetime.strptime(sla['eol'], '%Y-%m-%d').date()

--- a/pdcupdater/tests/handler_tests/test_retirement.py
+++ b/pdcupdater/tests/handler_tests/test_retirement.py
@@ -1,0 +1,116 @@
+from pdcupdater.tests.handler_tests import BaseHandlerTest, mock_pdc
+import pdcupdater.services
+
+
+class TestRetiredComponents(BaseHandlerTest):
+    handler_path = 'pdcupdater.handlers.retirement:RetireComponentHandler'
+
+    def test_can_handle_retire_msg(self):
+        idx = '2017-b1adac6d-64e9-406f-a1f4-4d3e57105649'
+        msg = pdcupdater.utils.get_fedmsg(idx)
+        result = self.handler.can_handle(None, msg)
+        self.assertTrue(result)
+
+    def test_cannot_handle_unretire_msg(self):
+        idx = '2017-d20c1ee0-9c00-4ab8-9364-0fdf120e822c'
+        msg = pdcupdater.utils.get_fedmsg(idx)
+        result = self.handler.can_handle(None, msg)
+        self.assertFalse(result)
+
+    @mock_pdc
+    def test_can_process_retire_msg(self, pdc):
+        pdc.add_endpoint('component-branches', 'GET', [
+            {
+                "id": 89151,
+                "global_component": "iwhd",
+                "name": "f26",
+                "slas": [
+                    {
+                        "id": 178020,
+                        "sla": "bug_fixes",
+                        "eol": "2222-07-01"
+                    },
+                    {
+                        "id": 178028,
+                        "sla": "security_fixes",
+                        "eol": "2222-07-01"
+                    }
+                ],
+                "type": "rpm",
+                "active": True,
+                "critical_path": False
+            }
+        ])
+        pdc.add_endpoint('component-branch-slas', 'GET', [
+            {
+                "id": 178020,
+                "sla": "bug_fixes",
+                "branch": {
+                    "id": 89151,
+                    "name": "f26",
+                    "global_component": "iwhd",
+                    "type": "rpm",
+                    "critical_path": False,
+                    "active": True
+                },
+                "eol": "2222-07-01"
+            },
+            {
+                "id": 178028,
+                "sla": "security_fixes",
+                "branch": {
+                    "id": 89151,
+                    "name": "f26",
+                    "global_component": "iwhd",
+                    "type": "rpm",
+                    "critical_path": False,
+                    "active": True
+                },
+                "eol": "2222-07-01"
+            }
+        ])
+        pdc.add_endpoint('component-branch-slas/178020', 'PATCH', 'ok')
+        pdc.add_endpoint('component-branch-slas/178028', 'PATCH', 'ok')
+
+        idx = '2017-b1adac6d-64e9-406f-a1f4-4d3e57105649'
+        msg = pdcupdater.utils.get_fedmsg(idx)
+        self.handler.handle(pdc, msg)
+        expected_keys = [
+            'component-branches',
+            'component-branch-slas/178020',
+            'component-branch-slas/178028'
+        ]
+        self.assertEquals(pdc.calls.keys(), expected_keys)
+
+    @mock_pdc
+    def test_can_process_retire_msg_already_retired(self, pdc):
+        pdc.add_endpoint('component-branches', 'GET', [
+            {
+                "id": 155867,
+                "global_component": "obexftp",
+                "name": "f26",
+                "slas": [
+                    {
+                        "id": 310591,
+                        "sla": "bug_fixes",
+                        "eol": "2017-06-28"
+                    },
+                    {
+                        "id": 310602,
+                        "sla": "security_fixes",
+                        "eol": "2017-06-28"
+                    }
+                ],
+                "type": "rpm",
+                "active": False,
+                "critical_path": False
+            }
+        ])
+
+        idx = '2017-3f490f4d-7612-4881-80cb-e1a941d6d700'
+        msg = pdcupdater.utils.get_fedmsg(idx)
+        self.handler.handle(pdc, msg)
+        expected_keys = [
+            'component-branches'
+        ]
+        self.assertEquals(pdc.calls.keys(), expected_keys)


### PR DESCRIPTION
This PR doesn't implement an `audit` function. Is it worth the effort considering accuracy would require a lot of querying of datagrepper?