### PR TITLE
Handle case where release[dist_git] contains an explicit None.

### DIFF
--- a/pdcupdater/utils.py
+++ b/pdcupdater/utils.py
@@ -560,7 +560,7 @@ def releaseid2branch(pdc, release_id):
     """
     release = pdc['releases'][release_id]._()
     # May return `None` if undefined.
-    return release.get('dist_git', {}).get('branch')
+    return (release.get('dist_git') or {}).get('branch')
 
 
 def subpackage2parent(package, pdc_release):


### PR DESCRIPTION
Message
-------
[2017-08-17 01:49:06][    fedmsg   ERROR]
```python
{'body': {u'username': u'apache', u'certificate': u'LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUVTakNDQTdPZ0F3SUJBZ0lDQWRzd0RRWUpL\nb1pJaHZjTkFRRUZCUUF3Z2FBeEN6QUpCZ05WQkFZVEFsVlQKTVFzd0NRWURWUVFJRXdKT1F6RVFN\nQTRHQTFVRUJ4TUhVbUZzWldsbmFERVhNQlVHQTFVRUNoTU9SbVZrYjNKaApJRkJ5YjJwbFkzUXhE\nekFOQmdOVkJBc1RCbVpsWkcxelp6RVBNQTBHQTFVRUF4TUdabVZrYlhObk1ROHdEUVlEClZRUXBF\nd1ptWldSdGMyY3hKakFrQmdrcWhraUc5dzBCQ1FFV0YyRmtiV2x1UUdabFpHOXlZWEJ5YjJwbFkz\nUXUKYjNKbk1CNFhEVEUxTURFd05USXhNemd5TVZvWERUSTFNREV3TWpJeE16Z3lNVm93Z2RneEN6\nQUpCZ05WQkFZVApBbFZUTVFzd0NRWURWUVFJRXdKT1F6RVFNQTRHQTFVRUJ4TUhVbUZzWldsbmFE\nRVhNQlVHQTFVRUNoTU9SbVZrCmIzSmhJRkJ5YjJwbFkzUXhEekFOQmdOVkJBc1RCbVpsWkcxelp6\nRXJNQ2tHQTFVRUF4TWlhMjlxYVMxcmIycHAKTURFdWNHaDRNaTVtWldSdmNtRndjbTlxWldOMExt\nOXlaekVyTUNrR0ExVUVLUk1pYTI5cWFTMXJiMnBwTURFdQpjR2g0TWk1bVpXUnZjbUZ3Y205cVpX\nTjBMbTl5WnpFbU1DUUdDU3FHU0liM0RRRUpBUllYWVdSdGFXNUFabVZrCmIzSmhjSEp2YW1WamRD\nNXZjbWN3Z1o4d0RRWUpLb1pJaHZjTkFRRUJCUUFEZ1kwQU1JR0pBb0dCQU9PaSt4VEsKSStQdEU2\nMll0ZkkzM3
 g4bW5UUE1ZU0hDZHB3NkhCNjZlbU1qeHRyMU95a082alY4NERQS1JDdzVFWCswUEV2\nbgozNFo2MCtKOXkxMS9JZzRuYTBhNlA5aVI5TlNXb1o3cENwQ3NMRUZIeFJUM0tqVlg4V3JkeURX\ndVRaSXNBN0c3CkVSL2wyRzlKaDBKSmVCNDBBcm9LMTJEeGllMjZ1dFQ5SHJpN0FnTUJBQUdqZ2dG\nWE1JSUJVekFKQmdOVkhSTUUKQWpBQU1DMEdDV0NHU0FHRytFSUJEUVFnRmg1RllYTjVMVkpUUVNC\nSFpXNWxjbUYwWldRZ1EyVnlkR2xtYVdOaApkR1V3SFFZRFZSME9CQllFRkxNVGpXekFPOURmYU83\nT1h0K2VkdFVMd2I3Vk1JSFZCZ05WSFNNRWdjMHdnY3FBCkZHdEFXdmtTQ0lsWjUxbmxCZlVDSFFw\nT2Z4UUFvWUdtcElHak1JR2dNUXN3Q1FZRFZRUUdFd0pWVXpFTE1Ba0cKQTFVRUNCTUNUa014RURB\nT0JnTlZCQWNUQjFKaGJHVnBaMmd4RnpBVkJnTlZCQW9URGtabFpHOXlZU0JRY205cQpaV04wTVE4\nd0RRWURWUVFMRXdabVpXUnRjMmN4RHpBTkJnTlZCQU1UQm1abFpHMXpaekVQTUEwR0ExVUVLUk1H\nClptVmtiWE5uTVNZd0pBWUpLb1pJaHZjTkFRa0JGaGRoWkcxcGJrQm1aV1J2Y21Gd2NtOXFaV04w\nTG05eVo0SUoKQU9OUUhrZFBGeDVGTUJNR0ExVWRKUVFNTUFvR0NDc0dBUVVGQndNQ01Bc0dBMVVk\nRHdRRUF3SUhnREFOQmdrcQpoa2lHOXcwQkFRVUZBQU9CZ1FCU2hrTnZ5ZzdvclZxbVVXdHdmZHpW\nUS92QnFXWkp1bys2a0RwckJIYUJlVWdmClA2RExEUEVPN3JHZXlxaFVtb0U3dmRVRHBGeE5
 mbC9E\nemtBOHJBRWVsMjdGUXZ5RVFkUDJFaHpPUjZlTldwT0cKdEVJU0RML1piRFgwZzRrSWR5YjVoWGZY\nbUJzbzQ1RmdPYkNGUkdsTlg5SUU1Ly95bmxCZU5CMzEvYlk1bmc9PQotLS0tLUVORCBDRVJUSUZJ\nQ0FURS0tLS0tCg==\n', u'i': 1, u'timestamp': 1502934544, u'msg_id': u'2017-06908fef-4314-481f-addd-4824261ee0bb', u'crypto': u'x509', u'topic': u'org.fedoraproject.prod.buildsys.tag', 'headers': {}, u'signature': u'A2liVYzeXQJbwFbmfEsb1/t1Mr9Z93F0O/H9KId9/0Ay+A6zF2VZHkEI0QyrZLow9GNpJWeXaThO\n+sK8eahUVQQUe9INOm9jEL0NDeN/VZ15ftnWIQRivqufDuY1ra3JYVQJwY3jMUOpuwiSUWlSuh4z\ng/yoeHRCj4IBtsTwVRw=\n', u'msg': {u'build_id': 956404, u'name': u'kubernetes-controller-manager', u'tag_id': 741, u'instance': u'primary', u'tag': u'f26-container', u'user': u'containerbuild', u'version': u'0', u'owner': u'containerbuild', u'release': u'1.f26container'}}, 'topic': u'org.fedoraproject.prod.buildsys.tag'}
```


Process Details
---------------
- host:     pdc-backend03.phx2.fedoraproject.org
- PID:      9913
- name:     fedmsg-hub
- command:  /usr/bin/python /usr/bin/fedmsg-hub
- msg_id:   

Callstack that lead to the logging statement
--------------------------------------------
```python
  File "/usr/lib64/python2.7/threading.py", line 785 in __bootstrap
    self.__bootstrap_inner()
  File "/usr/lib64/python2.7/threading.py", line 812 in __bootstrap_inner
    self.run()
  File "/usr/lib64/python2.7/threading.py", line 765 in run
    self.__target(*self.__args, **self.__kwargs)
  File "/usr/lib64/python2.7/site-packages/twisted/python/threadpool.py", line 167 in _worker
    result = context.call(ctx, function, *args, **kwargs)
  File "/usr/lib64/python2.7/site-packages/twisted/python/context.py", line 118 in callWithContext
    return self.currentContext().callWithContext(ctx, func, *args, **kw)
  File "/usr/lib64/python2.7/site-packages/twisted/python/context.py", line 81 in callWithContext
    return func(*args,**kw)
  File "/usr/lib/python2.7/site-packages/moksha/hub/api/consumer.py", line 193 in _work
    self.log.exception(message)
```

```python
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/moksha/hub/api/consumer.py", line 191, in _work
    self.consume(message)
  File "/usr/lib/python2.7/site-packages/pdcupdater/consumer.py", line 69, in consume
    pdcupdater.utils.handle_message(pdc, self.handlers, msg)
  File "/usr/lib/python2.7/site-packages/pdcupdater/utils.py", line 474, in handle_message
    handler.handle(client, msg)
  File "/usr/lib/python2.7/site-packages/pdcupdater/handlers/depchain/base.py", line 160, in handle
    pdc, release_id, parent_name, type=self.parent_type)
  File "/usr/lib/python2.7/site-packages/pdcupdater/utils.py", line 120, in ensure_release_component_exists
    'dist_git_branch': releaseid2branch(pdc, release_id),
  File "/usr/lib/python2.7/site-packages/dogpile/cache/region.py", line 1053, in decorate
    should_cache_fn)
  File "/usr/lib/python2.7/site-packages/dogpile/cache/region.py", line 657, in get_or_create
    async_creator) as value:
  File "/usr/lib/python2.7/site-packages/dogpile/core/dogpile.py", line 158, in __enter__
    return self._enter()
  File "/usr/lib/python2.7/site-packages/dogpile/core/dogpile.py", line 98, in _enter
    generated = self._enter_create(createdtime)
  File "/usr/lib/python2.7/site-packages/dogpile/core/dogpile.py", line 149, in _enter_create
    created = self.creator()
  File "/usr/lib/python2.7/site-packages/dogpile/cache/region.py", line 625, in gen_value
    created_value = creator()
  File "/usr/lib/python2.7/site-packages/dogpile/cache/region.py", line 1049, in creator
    return fn(*arg, **kw)
  File "/usr/lib/python2.7/site-packages/pdcupdater/utils.py", line 563, in releaseid2branch
    return release.get('dist_git', {}).get('branch')
AttributeError: 'NoneType' object has no attribute 'get'
```