### PR TITLE
Fix PDC mocks on the latest pdc_client version and add Travis CI

### DIFF
--- a/.travis-Dockerfile
+++ b/.travis-Dockerfile
@@ -1,0 +1,31 @@
+FROM centos
+
+WORKDIR /build
+
+RUN yum -y update && \
+    yum -y install epel-release yum-config-manager centos-release-scl && \
+    yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+    yum -y install \
+        --setopt=deltarpm=0 \
+        --setopt=install_weak_deps=false \
+        --setopt=tsflags=nodocs \
+        gcc \
+        gcc-c++ \
+        krb5-devel \
+        libffi-devel \
+        libyaml-devel \
+        openssl-devel \
+        python27 \
+        python-devel \
+        python-pip \
+        redhat-rpm-config \
+        swig \
+        zeromq-devel &&\
+    yum clean all
+
+COPY . .
+
+RUN scl enable python27 'pip install --upgrade pip setuptools koji' && \
+    scl enable python27 'python setup.py develop && pip install -r test-requirements.txt'
+
+CMD ["scl", "enable", "python27", "pytest -v pdcupdater/tests/"]

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: generic
+sudo: required
+services: docker
+install:
+  - docker build -t pdc-updater-tests -f .travis-Dockerfile .
+script:
+  - docker run pdc-updater-tests

--- a/pdcupdater/tests/handler_tests/test_kerberos_auth.py
+++ b/pdcupdater/tests/handler_tests/test_kerberos_auth.py
@@ -1,23 +1,22 @@
-import pytest
-import requests_kerberos
-from mock import patch, Mock
-import pdcupdater.utils
-from test.test_support import EnvironmentVarGuard
 import os
 
-class TestKerberosAuthentication(object):
+from mock import patch, Mock
 
-	@patch('os.path.exists', return_value=True)
-	@patch('requests_kerberos.HTTPKerberosAuth')
-	@patch('requests.get')
-	def test_get_token(self, requests_get, kerb_auth, os_path):
-		self.url = 'https://pdc.fedoraproject.org/rest_api/v1/'
-		set_env=patch.dict(os.environ,{'KRB5_CLIENT_KTNAME': '/etc/foo.keytab'})
-		requests_rv = Mock()
-		requests_rv.json.return_value = {"token": "12345"}
-		requests_get.return_value = requests_rv
-		set_env.start()
-		rv = pdcupdater.utils.get_token(self.url,
-			'/etc/foo.keytab')
-		set_env.stop()
-		assert rv == '12345'
+import pdcupdater.utils
+
+
+class TestKerberosAuthentication(object):
+    @patch('os.path.exists', return_value=True)
+    @patch('requests_kerberos.HTTPKerberosAuth')
+    @patch('requests.get')
+    def test_get_token(self, requests_get, kerb_auth, os_path):
+        self.url = 'https://pdc.fedoraproject.org/rest_api/v1/'
+        set_env = patch.dict(
+            os.environ, {'KRB5_CLIENT_KTNAME': '/etc/foo.keytab'})
+        requests_rv = Mock()
+        requests_rv.json.return_value = {"token": "12345"}
+        requests_get.return_value = requests_rv
+        set_env.start()
+        rv = pdcupdater.utils.get_token(self.url, '/etc/foo.keytab')
+        set_env.stop()
+        assert rv == '12345'


### PR DESCRIPTION
The latest pdc_client version doesn't have `pdc_client.test_helpers.mock_api` anymore. This PR just replicates what that function did.

This PR also removes an invalid import that caused tests to fail and fixes some PEP8 in the test file that was causing failures.

Lastly, this PR configures TravisCI to run on pull-requests.