### PR TITLE
Remove code for the non-existent "trees" PDC API

### DIFF
--- a/pdcupdater/handlers/modules.py
+++ b/pdcupdater/handlers/modules.py
@@ -16,16 +16,12 @@ log = logging.getLogger(__name__)
 class ModuleStateChangeHandler(pdcupdater.handlers.BaseHandler):
     """ When the state of a module changes. """
 
-    tree_processing_states = set(('done', 'ready'))
+    processing_states = set(('done', 'ready'))
     other_states = set(('wait', 'building'))
     irrelevant_states = set(('init', 'build',))
-    relevant_states = tree_processing_states.union(other_states)
+    relevant_states = processing_states.union(other_states)
     error_states = set(('failed',))
     valid_states = relevant_states.union(error_states).union(irrelevant_states)
-
-    tree_id_re = re.compile(
-        r"(?P<name>[^-]+)-(?P<version>[^-]+)-"
-        r"(?P<date>[0-9]{8})\.(?P<spin>[0-9]+)")
 
     rpm_fname_re = re.compile(
         r"(?P<name>.+)-"
@@ -134,11 +130,6 @@ class ModuleStateChangeHandler(pdcupdater.handlers.BaseHandler):
                 # *always* throws a typeerror afterwards, which can be ignored.
                 pass
 
-        # trees are only present when a module is done building, i.e. states
-        # 'done' or 'ready'
-        if 'topdir' in body:
-            self.handle_new_tree(pdc, body, unreleased_variant)
-
     def create_unreleased_variant(self, pdc, body):
         """Creates an UnreleasedVariant for a module in PDC. Checks out the
         module metadata from the supplied SCM repository (currently only
@@ -205,111 +196,8 @@ class ModuleStateChangeHandler(pdcupdater.handlers.BaseHandler):
             unreleased_variant = unreleased_variants[0]
         return unreleased_variant
 
-    def handle_new_tree(self, pdc, body, unreleased_variant):
-        log.debug("handle_new_tree(pdc, body, unreleased_variant=%r)" % unreleased_variant)
-        topdir = body['topdir']
-        tree_id = os.path.basename(topdir)
-
-        log.debug("Trying to import tree from topdir '{}'".format(topdir))
-
-        m = self.tree_id_re.match(tree_id)
-        if not m:
-            log.error("Unexpected tree id: '{}'".format(tree_id))
-            return
-
-        tree_date = m.group('date')
-        tree_date = (
-            tree_date[0:4] + "-" + tree_date[4:6] + "-" + tree_date[6:8])
-
-        # avoid adding trees twice
-        try:
-            pdc['trees'][tree_id]._()
-        except beanbag.BeanBagException as e:
-            if e.response.status_code != 404:
-                raise
-        else:
-            log.info("Tree exists already, skipping: {}".format(tree_id))
-            return
-
-        arches = [x['name'] for x in pdc['arches']._(page_size=-1)]
-
-        for arch in arches:
-            archdir = os.path.join(topdir, arch)
-            tree_dict = {
-                'arch': arch,
-                'variant': unreleased_variant,
-                'content_format': ['rpm'],
-                'content': {'rpms': {}},
-                'url': archdir,
-                'tree_id': tree_id,
-                'tree_date': tree_date,
-            }
-
-            content_dict = tree_dict['content']['rpms']
-
-            # just grab RPMs from base dir, TODO: retrieve from repodata?
-            try:
-                fnames = os.listdir(archdir)
-            except OSError as e:
-                if e.errno == errno.ENOENT:
-                    log.debug("Skipping non-existent arch {}".format(arch))
-                    continue
-                raise
-
-            for fname in sorted(fnames):
-                m = self.rpm_fname_re.match(fname)
-                if not m:
-                    log.debug("Skipping over non-RPM file {}".format(fname))
-                    continue
-
-                fname_wo_rpm = fname[:-4]
-
-                rpminfo = m.groupdict()
-
-                # TODO: debug RPM category
-                if rpminfo['arch'] == 'src':
-                    category = 'source'
-                else:
-                    category = 'binary'
-
-                # TODO: extract RPM signature key?
-                sigkey = None
-
-                fpath = os.path.join(archdir, fname)
-
-                content_dict[fname_wo_rpm] = {
-                    'category': category,
-                    'path': fpath,
-                    'sigkey': sigkey
-                }
-
-            pdc['trees']._(tree_dict)
-
     def audit(self, pdc):
-        # TODO: find out what trees exist in koji
-
-        # # Query the data sources
-        # koji_trees = sum(self._gather_koji_rpms(), [])
-        # pdc_trees = pdc.get_paged(pdc['trees']._)
-
-        # # Normalize the lists before comparing them.
-        # koji_rpms = set([json.dumps(r, sort_keys=True) for r in koji_rpms])
-        # pdc_rpms = set([json.dumps(r, sort_keys=True) for r in pdc_rpms])
-
-        # # use set operators to determine the difference
-        # present = pdc_rpms - koji_rpms
-        # absent = koji_rpms - pdc_rpms
-
-        # return present, absent
-
         pass
 
     def initialize(self, pdc):
-
-        ## Get a list of all rpms in koji and send it to PDC
-        #for batch in self._gather_koji_rpms():
-        #    log.info("Uploading info about %i rpms to PDC." % len(batch))
-        #    for entry in batch:
-        #        pdc['rpms']._(entry)
-
         pass

--- a/pdcupdater/tests/handler_tests/__init__.py
+++ b/pdcupdater/tests/handler_tests/__init__.py
@@ -52,7 +52,6 @@ def mock_pdc(function):
         pdc.add_endpoint('compose-rpms', 'POST', 'wat')
         pdc.add_endpoint('persons', 'POST', 'wat')
         pdc.add_endpoint('rpms', 'POST', 'wat')
-        pdc.add_endpoint('trees', 'POST', 'wat')
         pdc.add_endpoint('unreleasedvariants', 'POST', 'wat')
 
         # One delete endpoint for single deletes
@@ -333,7 +332,6 @@ def mock_pdc(function):
         }])
 
         pdc.add_endpoint('unreleasedvariants/core-24-0', 'GET', mock_404)
-        pdc.add_endpoint('trees/Test-0-20160712.0', 'GET', mock_404)
 
         return function(self, pdc, *args, **kwargs)
     pdc_patcher.stop()

--- a/pdcupdater/tests/handler_tests/test_modules.py
+++ b/pdcupdater/tests/handler_tests/test_modules.py
@@ -70,7 +70,6 @@ class TestModuleStateChange(BaseHandlerTest):
     foo_repo_tar = os.path.join(repo_dir, "foo.tar")
     foo_repo_dir = os.path.join(repo_dir, "foo")
     foo_repo_url = foo_repo_dir + '?#286f3a32f3e034508012fcbba63ed40092e4129b'
-    test_tree_dir = os.path.join(test_data_dir, "trees/Test-0-20160712.0")
 
     state_init_msg = {
         'topic': 'org.fedoraproject.stg.mbs.module.state.change',
@@ -89,8 +88,7 @@ class TestModuleStateChange(BaseHandlerTest):
     state_done_msg['topic'] = 'org.fedoraproject.stg.mbs.module.state.change'
     state_done_msg['msg'].update({
         'state': 3,
-        'state_name': 'done',
-        'topdir': test_tree_dir
+        'state_name': 'done'
     })
 
     def setUp(self):
@@ -115,7 +113,7 @@ class TestModuleStateChange(BaseHandlerTest):
         self.handler.handle(pdc, self.state_init_msg)
 
     @mock_pdc
-    def test_handle_created_tree(self, pdc):
+    def test_update_unreleased_variant(self, pdc):
         self.handler.handle(pdc, self.state_done_msg)
 
 


### PR DESCRIPTION
Originally, the the module API used by MBS was called "trees". This API no longer exists in PDC and should be dropped from pdc-updater.