### PR TITLE
Use more informative koji tag name for module builds

### DIFF
--- a/.travis-Dockerfile
+++ b/.travis-Dockerfile
@@ -3,8 +3,7 @@ FROM centos
 WORKDIR /build
 
 RUN yum -y update && \
-    yum -y install epel-release yum-config-manager centos-release-scl && \
-    yum-config-manager --enable rhel-server-rhscl-7-rpms && \
+    yum -y install epel-release && \
     yum -y install \
         --setopt=deltarpm=0 \
         --setopt=install_weak_deps=false \
@@ -20,12 +19,15 @@ RUN yum -y update && \
         python-pip \
         redhat-rpm-config \
         swig \
-        zeromq-devel &&\
+        zeromq-devel \
+        rpm-devel \
+        python2-koji \
+        libmodulemd && \
     yum clean all
 
 COPY . .
 
-RUN scl enable python27 'pip install --upgrade pip setuptools koji' && \
-    scl enable python27 'python setup.py develop && pip install -r test-requirements.txt'
+RUN pip install --upgrade pip setuptools && \
+    python setup.py develop && pip install -r test-requirements.txt
 
-CMD ["scl", "enable", "python27", "pytest -v pdcupdater/tests/"]
+CMD ["pytest", "-v", "pdcupdater/tests/"]

--- a/pdcupdater/handlers/modules.py
+++ b/pdcupdater/handlers/modules.py
@@ -8,8 +8,6 @@ import pdc_client
 import pdcupdater.handlers
 import pdcupdater.services
 
-import hashlib
-
 import gi
 gi.require_version('Modulemd', '1.0') # noqa
 from gi.repository import Modulemd
@@ -170,9 +168,11 @@ class ModuleStateChangeHandler(pdcupdater.handlers.BaseHandler):
         name = body['name']
         stream = body['stream']
         version = body['version']
-        tag_str = '.'.join(self.get_uid(body).split(':'))
-        tag_hash = hashlib.sha1(tag_str).hexdigest()[:16]
-        koji_tag = 'module-' + tag_hash
+        tag_str = '-'.join(self.get_uid(body).split(':'))
+        if self.pdc_api == 'unreleasedvariants':
+            # context is not available under unreleasedvariants endpoint
+            tag_str += '-00000000'
+        koji_tag = 'module-' + tag_str
 
         if self.pdc_api == 'modules':
             data = {

--- a/pdcupdater/tests/handler_tests/__init__.py
+++ b/pdcupdater/tests/handler_tests/__init__.py
@@ -329,7 +329,7 @@ def mock_pdc(function):
             'variant_type': 'module',
             'variant_version': 'master',
             'variant_release': '20180123171544',
-            'koji_tag': 'module-ce2adf69caf0e1b5',
+            'koji_tag': 'module-testmodule-master-20180123171544-00000000',
             'runtime_deps': [
                 {
                     'dependency': 'platform',

--- a/pdcupdater/tests/handler_tests/test_modules.py
+++ b/pdcupdater/tests/handler_tests/test_modules.py
@@ -183,7 +183,7 @@ class TestModuleStateChange(BaseHandlerTest):
         self.assertEqual(pdc.calls['unreleasedvariants'][1][0], 'POST')
         expected_post = {
             'build_deps': [{'dependency': 'platform', 'stream': 'f28'}],
-            'koji_tag': 'module-ce2adf69caf0e1b5',
+            'koji_tag': 'module-testmodule-master-20180123171544-00000000',
             'modulemd': self.modulemd_example,
             'runtime_deps': [{'dependency': 'platform', 'stream': 'f28'}],
             'variant_id': 'testmodule',
@@ -246,7 +246,7 @@ class TestModuleStateChange(BaseHandlerTest):
         self.assertEqual(pdc.calls['modules'][2][0], 'POST')
         expected_post = {
             'build_deps': [{'dependency': 'platform', 'stream': 'f28'}],
-            'koji_tag': 'module-67eff7c74088acdf',
+            'koji_tag': 'module-testmodule-master-20180123171544-c2c572ec',
             'modulemd': self.modulemd_example,
             'runtime_deps': [{'dependency': 'platform', 'stream': 'f28'}],
             'name': 'testmodule',


### PR DESCRIPTION
koji now supports tags with max length of 256, we can use
more informative tag name instead of the hash one.

The new format of koji tag name is:

    module-<name>-<stream>-<version>-<context>

<context> for modules under 'unreleasedvariants' endpoint
is '00000000'.

FIXES: https://pagure.io/fm-orchestrator/issue/918