### PR TITLE
Add option for new AAA backend

### DIFF
--- a/.travis-Dockerfile
+++ b/.travis-Dockerfile
@@ -12,7 +12,6 @@ RUN yum -y update && \
         gcc-c++ \
         krb5-devel \
         libffi-devel \
-        libyaml-devel \
         openssl-devel \
         python3-devel \
         python3-pip \

--- a/.travis-Dockerfile
+++ b/.travis-Dockerfile
@@ -14,14 +14,13 @@ RUN yum -y update && \
         libffi-devel \
         libyaml-devel \
         openssl-devel \
-        python27 \
-        python-devel \
-        python-pip \
+        python3-devel \
+        python3-pip \
         redhat-rpm-config \
         swig \
         zeromq-devel \
         rpm-devel \
-        python2-koji \
+        python3-koji \
         libmodulemd && \
     yum clean all
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -13,8 +13,7 @@ $script = <<SCRIPT
         zeromq-devel \
         koji \
         swig \
-        fedmsg \
-        libyaml-devel
+        fedmsg
     cd /opt/pdc-updater/src
     python setup.py develop
     pip install -r test-requirements.txt

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -21,7 +21,7 @@ $script = <<SCRIPT
 SCRIPT
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "fedora/24-cloud-base"
+  config.vm.box = "fedora/31-cloud-base"
   config.vm.provider :virtualbox do |v|
     v.customize ["modifyvm", :id, "--memory", 2048]
   end

--- a/pdcupdater/services.py
+++ b/pdcupdater/services.py
@@ -81,7 +81,7 @@ def fas_persons(base_url, username, password, freeipa_backend):
     log.info("Connecting to Account System at %r" % base_url)
     if freeipa_backend:
         client = Client(url=base_url)
-        response = client.users.list_users().response().result
+        response = client.list_users().result
         people = response.get('result', [])
         return people
 

--- a/pdcupdater/services.py
+++ b/pdcupdater/services.py
@@ -82,7 +82,8 @@ def fas_persons(base_url, username, password, freeipa_backend):
     if freeipa_backend:
         client = Client(url=base_url)
         response = client.users.list_users().response().result
-        return response['result']
+        people = response.get('result', [])
+        return people
 
     import fedora.client
     import fedora.client.fas2

--- a/pdcupdater/services.py
+++ b/pdcupdater/services.py
@@ -75,11 +75,11 @@ def old_composes(base_url):
 
 
 @pdcupdater.utils.with_ridiculous_timeout
-def fas_persons(base_url, username, password, freeipa_backend):
+def fas_persons(base_url, username, password, fasjson):
     """ Return the list of users in the Fedora Account System. """
 
     log.info("Connecting to Account System at %r" % base_url)
-    if freeipa_backend:
+    if fasjson:
         client = Client(url=base_url)
         response = client.list_users().result
         people = response.get('result', [])

--- a/pdcupdater/services.py
+++ b/pdcupdater/services.py
@@ -81,8 +81,7 @@ def fas_persons(base_url, username, password, fasjson):
     log.info("Connecting to Account System at %r" % base_url)
     if fasjson:
         client = Client(url=base_url)
-        response = client.list_users().result
-        people = response.get('result', [])
+        people = client.list_users().result
         return people
 
     import fedora.client

--- a/pdcupdater/services.py
+++ b/pdcupdater/services.py
@@ -1,8 +1,11 @@
 import logging
 import operator
+import os
 
 import bs4
 import requests
+
+from fasjson_client import Client
 
 import pdcupdater.handlers.compose
 import pdcupdater.utils
@@ -72,13 +75,18 @@ def old_composes(base_url):
 
 
 @pdcupdater.utils.with_ridiculous_timeout
-def fas_persons(base_url, username, password):
+def fas_persons(base_url, username, password, freeipa_backend):
     """ Return the list of users in the Fedora Account System. """
+
+    log.info("Connecting to Account System at %r" % base_url)
+    if freeipa_backend:
+        client = Client(url=base_url)
+        response = client.users.list_users().response().result
+        return response['result']
 
     import fedora.client
     import fedora.client.fas2
 
-    log.info("Connecting to FAS at %r" % base_url)
     fasclient = fedora.client.fas2.AccountSystem(
         base_url=base_url, username=username, password=password)
 

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ requirements = [
     'pdc-client',
     'six',
     'modulemd',
+    'fasjson-client',
 ]
 
 


### PR DESCRIPTION
this commit adds the ability to query users from the freeipa
backend instead of fas. the freeipa_backend config variable
will be added to the ansible repo and turned to False by default.

Signed-off-by: Stephen Coady <scoady@redhat.com>